### PR TITLE
Variables have different name in code and definition

### DIFF
--- a/src/GCECredentials.php
+++ b/src/GCECredentials.php
@@ -71,7 +71,7 @@ class GCECredentials implements FetchAuthTokenInterface
   /**
    * Flag that stores the value of the onGCE check.
    */
-  private $isOnGCE = false;
+  private $isOnGce = false;
 
   /**
    * The full uri for accessing the default token.

--- a/src/OAuth2.php
+++ b/src/OAuth2.php
@@ -87,7 +87,7 @@ class OAuth2 implements FetchAuthTokenInterface
   /**
    * The resource owner's username.
    */
-  private $userName;
+  private $username;
 
   /**
    * The scope of the access request, expressed either as an Array or as a

--- a/src/OAuth2.php
+++ b/src/OAuth2.php
@@ -90,6 +90,11 @@ class OAuth2 implements FetchAuthTokenInterface
   private $username;
 
   /**
+   * The resource owner's password.
+   */
+  private $password;
+
+  /**
    * The scope of the access request, expressed either as an Array or as a
    * space-delimited string.
    */


### PR DESCRIPTION
Fixes https://github.com/google/google-auth-library-php/issues/37