### PR TITLE
increase timeout on gce connection

### DIFF
--- a/src/GCECredentials.php
+++ b/src/GCECredentials.php
@@ -105,7 +105,7 @@ class GCECredentials extends CredentialsLoader
       // could lead to false negatives in the event that we are on GCE, but
       // the metadata resolution was particularly slow. The latter case is
       // "unlikely".
-      $resp = $client->get($checkUri, ['timeout' => 0.1]);
+      $resp = $client->get($checkUri, ['timeout' => 0.3]);
       return $resp->getHeader(self::FLAVOR_HEADER) == 'Google';
     } catch (ClientException $e) {
       return false;


### PR DESCRIPTION
I tracked down the intermittent error on the compute_engine test. When we connect to GCE to get the initial metadata, the call is set to have a timeout of 0.1s. That fails around 50% of the time. So I tested increasing the timeout:

failure rate:
 * 0.1s: 53%
 * 0.2s: 49%
 * 0.25s: 10%
 * 0.3s: 0%