### PR TITLE
adds client id/secret to code,refresh,and password grant types

### DIFF
--- a/src/OAuth2.php
+++ b/src/OAuth2.php
@@ -381,13 +381,16 @@ class OAuth2 implements FetchAuthTokenInterface
       case 'authorization_code':
         $params['code'] = $this->getCode();
         $params['redirect_uri'] = $this->getRedirectUri();
+        $this->addClientCredentials($params);
         break;
       case 'password':
         $params['username'] = $this->getUsername();
         $params['password'] = $this->getPassword();
+        $this->addClientCredentials($params);
         break;
       case 'refresh_token':
         $params['refresh_token'] = $this->getRefreshToken();
+        $this->addClientCredentials($params);
         break;
       case self::JWT_URN:
         $params['assertion'] = $this->toJwt();
@@ -1076,5 +1079,18 @@ class OAuth2 implements FetchAuthTokenInterface
   private function isAbsoluteUri($u)
   {
     return $u->getScheme() && ($u->getHost() || $u->getPath());
+  }
+
+  private function addClientCredentials(&$params)
+  {
+    $clientId = $this->getClientId();
+    $clientSecret = $this->getClientSecret();
+
+    if ($clientId && $clientSecret) {
+      $params['client_id'] = $clientId;
+      $params['client_secret'] = $clientSecret;
+    }
+
+    return $params;
   }
 }

--- a/tests/OAuth2Test.php
+++ b/tests/OAuth2Test.php
@@ -527,6 +527,38 @@ class OAuth2GenerateAccessTokenRequestTest extends \PHPUnit_Framework_TestCase
     $this->assertEquals('a_refresh_token', $fields['refresh_token']);
   }
 
+  public function testClientSecretAddedIfSetForAuthorizationCodeRequests()
+  {
+    $testConfig = $this->tokenRequestMinimal;
+    $testConfig['clientSecret'] = 'a_client_secret';
+    $testConfig['redirectUri'] = 'https://has/redirect/uri';
+    $o = new OAuth2($testConfig);
+    $o->setCode('an_auth_code');
+    $request = $o->generateCredentialsRequest();
+    $this->assertEquals('a_client_secret', $request->getBody()->getField('client_secret'));
+  }
+
+  public function testClientSecretAddedIfSetForRefreshTokenRequests()
+  {
+    $testConfig = $this->tokenRequestMinimal;
+    $testConfig['clientSecret'] = 'a_client_secret';
+    $o = new OAuth2($testConfig);
+    $o->setRefreshToken('a_refresh_token');
+    $request = $o->generateCredentialsRequest();
+    $this->assertEquals('a_client_secret', $request->getBody()->getField('client_secret'));
+  }
+
+  public function testClientSecretAddedIfSetForPasswordRequests()
+  {
+    $testConfig = $this->tokenRequestMinimal;
+    $testConfig['clientSecret'] = 'a_client_secret';
+    $o = new OAuth2($testConfig);
+    $o->setUsername('a_username');
+    $o->setPassword('a_password');
+    $request = $o->generateCredentialsRequest();
+    $this->assertEquals('a_client_secret', $request->getBody()->getField('client_secret'));
+  }
+
   public function testGeneratesAssertionRequests()
   {
     $testConfig = $this->tokenRequestMinimal;


### PR DESCRIPTION
the call to [`generateCredentialsRequest`](https://github.com/google/google-auth-library-php/blob/master/src/OAuth2.php#L369), called from [`fetchAuthToken`](https://github.com/google/google-auth-library-php/blob/master/src/OAuth2.php#L420), does not include the client credentials. This results in a `400 Bad Request`

```json
{
	"error": "invalid_request",
	"error_description": "Missing parameter: client_id"
}
```

I have changed this so the credentials are added to the request if they've been supplied to the 0Auth client