### PR TITLE
approvalPrompt should be approval_prompt

### DIFF
--- a/src/OAuth2.php
+++ b/src/OAuth2.php
@@ -552,9 +552,9 @@ class OAuth2 implements FetchAuthTokenInterface
     if (is_null($params->get('redirect_uri'))) {
       throw new \InvalidArgumentException('missing the required redirect URI');
     }
-    if ($params->hasKey('prompt') && $params->hasKey('approvalPrompt')) {
+    if ($params->hasKey('prompt') && $params->hasKey('approval_prompt')) {
       throw new \InvalidArgumentException(
-          'prompt and approvalPrompt are mutually exclusive');
+          'prompt and approval_prompt are mutually exclusive');
     }
 
     // Construct the uri object; return it if it is valid.

--- a/tests/OAuth2Test.php
+++ b/tests/OAuth2Test.php
@@ -77,7 +77,7 @@ class OAuth2AuthorizationUriTest extends \PHPUnit_Framework_TestCase
         'clientId' => 'aClientID'
     ]);
     $o->buildFullAuthorizationUri([
-        'approvalPrompt' => 'an approval prompt',
+        'approval_prompt' => 'an approval prompt',
         'prompt' => 'a prompt',
     ]);
   }


### PR DESCRIPTION
Current implementation generates a url with the value `approvalPrompt`:

    https://accounts.google.com/o/oauth2/auth?
	  response_type=code&
	  access_type=offline&
	  approvalPrompt=force

I cannot find any current documentation referencing `approval_prompt`, so I am thinking it's now deprecated. However, it definitely [existed at one point](http://www.riskcompletefailure.com/2013/12/are-you-using-approvalpromptforce.html) so it should be fixed or removed. I say we play it safe and just fix it.