### PR TITLE
allows the setting of subjects on the service account after the fact

### DIFF
--- a/src/ServiceAccountCredentials.php
+++ b/src/ServiceAccountCredentials.php
@@ -140,4 +140,13 @@ class ServiceAccountCredentials extends CredentialsLoader
     $jwtCreds = new ServiceAccountJwtAccessCredentials($credJson);
     return $jwtCreds->updateMetadata($metadata, $authUri, $client);
   }
+
+  /**
+   * @param string sub an email address account to impersonate, in situations when
+   *   the service account has been delegated domain wide access.
+   */
+  public function setSub($sub)
+  {
+    $this->auth->setSub($sub);
+  }
 }

--- a/tests/ServiceAccountCredentialsTest.php
+++ b/tests/ServiceAccountCredentialsTest.php
@@ -71,6 +71,24 @@ class SACGetCacheKeyTest extends \PHPUnit_Framework_TestCase
         $sa->getCacheKey()
     );
   }
+
+  public function testShouldBeTheSameAsOAuth2WithTheSameScopeWithSubAddedLater()
+  {
+    $testJson = createTestJson();
+    $scope = ['scope/1', 'scope/2'];
+    $sub = 'sub123';
+    $sa = new ServiceAccountCredentials(
+        $scope,
+        $testJson,
+        null);
+    $sa->setSub($sub);
+
+    $o = new OAuth2(['scope' => $scope]);
+    $this->assertSame(
+        $testJson['client_email'] . ':' . $o->getCacheKey() . ':' . $sub,
+        $sa->getCacheKey()
+    );
+  }
 }
 
 class SACConstructorTest extends \PHPUnit_Framework_TestCase


### PR DESCRIPTION
This allows [domain-wide auth](https://developers.google.com/identity/protocols/OAuth2ServiceAccount) in the php client library

Currently, in order to take advantage of domain-wide auth, you have to set the `$sub` parameter in the constructor. The problem with this is you lose the consistency of locating the credentials JSON file that exists in `CredentialsLoader`.

Adding `setSub` allows calls to `CredentialsLoader::fromEnv` and `CredentialsLoader::fromWellKnownFile` to return the `ServiceAccountCredentials` object, which then can have `setSub` called on it to "impersonate" a user.

This is not my favorite solution, but it is the only real way I can get this to work in the client library without some very ugly work-arounds. An alternative would be to add `getAuth` to return the `Google/Auth/OAuth2` object, but I like that solution even less.