### PR TITLE
AppIdentityCredentials expects array for multiple scopes

### DIFF
--- a/src/AppIdentityCredentials.php
+++ b/src/AppIdentityCredentials.php
@@ -102,7 +102,10 @@ class AppIdentityCredentials extends CredentialsLoader
       );
     }
 
-    $token = AppIdentityService::getAccessToken($this->scope);
+    // AppIdentityService expects an array when multiple scopes are supplied
+    $scope = is_array($this->scope) ? $this->scope : explode(' ', $this->scope);
+
+    $token = AppIdentityService::getAccessToken($scope);
 
     return $token;
   }

--- a/tests/AppIndentityCredentialsTest.php
+++ b/tests/AppIndentityCredentialsTest.php
@@ -58,7 +58,7 @@ class AppIdentityCredentialsFetchAuthTokenTest extends \PHPUnit_Framework_TestCa
   }
 
   /* @expectedException */
-  public function testTHrowsExceptionIfClassDoesntExist()
+  public function testThrowsExceptionIfClassDoesntExist()
   {
     $_SERVER['SERVER_SOFTWARE'] = 'Google App Engine';
     $g = new AppIdentityCredentials();
@@ -77,10 +77,33 @@ class AppIdentityCredentialsFetchAuthTokenTest extends \PHPUnit_Framework_TestCa
 
     AppIdentityService::$accessToken = $wantedToken;
 
-    // AppIdentityService::$accessToken = $wantedToken;
     $_SERVER['SERVER_SOFTWARE'] = 'Google App Engine';
 
     $g = new AppIdentityCredentials();
     $this->assertEquals($wantedToken, $g->fetchAuthToken());
+  }
+
+  public function testScopeIsAlwaysArray()
+  {
+    // include the mock AppIdentityService class
+    require_once __DIR__ . '/mocks/AppIdentityService.php';
+
+    $scope1 = ['scopeA', 'scopeB'];
+    $scope2 = 'scopeA scopeB';
+    $scope3 = 'scopeA';
+
+    $_SERVER['SERVER_SOFTWARE'] = 'Google App Engine';
+
+    $g = new AppIdentityCredentials($scope1);
+    $g->fetchAuthToken();
+    $this->assertEquals($scope1, AppIdentityService::$scope);
+
+    $g = new AppIdentityCredentials($scope2);
+    $g->fetchAuthToken();
+    $this->assertEquals(explode(' ', $scope2), AppIdentityService::$scope);
+
+    $g = new AppIdentityCredentials($scope3);
+    $g->fetchAuthToken();
+    $this->assertEquals([$scope3], AppIdentityService::$scope);
   }
 }

--- a/tests/mocks/AppIdentityService.php
+++ b/tests/mocks/AppIdentityService.php
@@ -4,6 +4,7 @@ namespace google\appengine\api\app_identity;
 
 class AppIdentityService
 {
+  public static $scope;
   public static $accessToken = array(
     'access_token' => 'xyz',
     'expiration_time' => '2147483646',
@@ -11,6 +12,8 @@ class AppIdentityService
 
   public static function getAccessToken($scope)
   {
+    self::$scope = $scope;
+
     return self::$accessToken;
   }
 }


### PR DESCRIPTION
When requesting multiple scopes on AppEngine, an error is thrown `An unknown scope was supplied.` This is because the library is passing a space-delimited string instead of an array. 