### PR TITLE
Upped dependency to Firebase 3.0, fixed use statements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "homepage": "http://github.com/google/google-auth-library-php",
   "license": "Apache-2.0",
   "require": {
-    "firebase/php-jwt": "2.0.0",
+    "firebase/php-jwt": "3.0.0",
     "guzzlehttp/guzzle": "5.2.*",
     "php": ">=5.4"
   },

--- a/src/OAuth2.php
+++ b/src/OAuth2.php
@@ -23,7 +23,7 @@ use GuzzleHttp\Collection;
 use GuzzleHttp\Query;
 use GuzzleHttp\Message\ResponseInterface;
 use GuzzleHttp\Url;
-use JWT;
+use Firebase\JWT\JWT;
 
 /**
  * OAuth2 supports authentication by OAuth2 2-legged flows.

--- a/tests/OAuth2Test.php
+++ b/tests/OAuth2Test.php
@@ -23,7 +23,7 @@ use GuzzleHttp\Message\Response;
 use GuzzleHttp\Stream\Stream;
 use GuzzleHttp\Subscriber\Mock;
 use GuzzleHttp\Url;
-use JWT;
+use Firebase\JWT\JWT;
 
 class OAuth2AuthorizationUriTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
We use a specific vendor for the slim framework and jwt authentication ( tuupola/slim-jwt-auth ) which requires firebase 3.0,

The differences according to the firebase log are
- namespacing
- better PHP Doc
- Require a non-empty key to decode and verify a JWT

(https://github.com/firebase/php-jwt/commit/fa8a06e96526eb7c0eeaa47e4f39be59d21f16e1)

The unittests succeed with these changes.