### PR TITLE
add support for guzzle 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,20 @@ language: php
 sudo: false
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - hhvm
 
 env:
-  - FIREBASE_JWT_VERSION=2.0.0
-  - FIREBASE_JWT_VERSION=3.0.0
+  - FIREBASE_JWT_VERSION=2.0.0 GUZZLE_VERSION=5.3
+  - FIREBASE_JWT_VERSION=2.0.0 GUZZLE_VERSION=~6.0
+  - FIREBASE_JWT_VERSION=3.0.0 GUZZLE_VERSION=5.3
+  - FIREBASE_JWT_VERSION=3.0.0 GUZZLE_VERSION=~6.0
 
 before_script:
   - composer install
   - composer require firebase/php-jwt:$FIREBASE_JWT_VERSION
+  - composer require guzzlehttp/guzzle:$GUZZLE_VERSION
 
 script:
   - vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -84,8 +84,9 @@ As long as you update the environment variable below to point to *your* JSON
 credentials file, the following code should output a list of your Drive files.
 
 ```php
-use GuzzleHttp\Client;
 use Google\Auth\ApplicationDefaultCredentials;
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
 
 // specify the path to your application credentials
 putenv('GOOGLE_APPLICATION_CREDENTIALS=/path/to/my/credentials.json');
@@ -93,21 +94,23 @@ putenv('GOOGLE_APPLICATION_CREDENTIALS=/path/to/my/credentials.json');
 // define the scopes for your API call
 $scopes = ['https://www.googleapis.com/auth/drive.readonly'];
 
+// create middleware
+$middleware = ApplicationDefaultCredentials::getMiddleware($scopes);
+$stack = HandlerStack::create();
+$stack->push($middleware);
+
 // create the HTTP client
 $client = new Client([
+  'handler' => $stack
   'base_url' => 'https://www.googleapis.com',
-  'defaults' => ['auth' => 'google_auth']  // authorize all requests
+  'auth' => 'google_auth'  // authorize all requests
 ]);
-
-// attach this library's auth listener
-$fetcher = ApplicationDefaultCredentials::getFetcher($scopes);
-$client->getEmitter()->attach($fetcher);
 
 // make the request
 $response = $client->get('drive/v2/files');
 
 // show the result!
-print_r($response->json());
+print_r((string) $response->getBody());
 ```
 
 ## What about auth in google-apis-php-client?

--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,10 @@
   "license": "Apache-2.0",
   "require": {
     "firebase/php-jwt": "~2.0|~3.0",
-    "guzzlehttp/guzzle": "5.2.*",
-    "php": ">=5.4"
+    "guzzlehttp/guzzle": "5.3|~6.0",
+    "php": ">=5.5",
+    "guzzlehttp/psr7": "1.2.*",
+    "psr/http-message": "1.0.*"
   },
   "require-dev": {
     "phpunit/phpunit": "3.7.*",

--- a/src/ApplicationDefaultCredentials.php
+++ b/src/ApplicationDefaultCredentials.php
@@ -17,8 +17,10 @@
 
 namespace Google\Auth;
 
-use GuzzleHttp\Stream\Stream;
-use GuzzleHttp\ClientInterface;
+use Google\Auth\Credentials\AppIdentityCredentials;
+use Google\Auth\Credentials\GCECredentials;
+use Google\Auth\Middleware\AuthTokenMiddleware;
+use Google\Auth\Subscriber\AuthTokenSubscriber;
 
 /**
  * ApplicationDefaultCredentials obtains the default credentials for
@@ -30,29 +32,35 @@ use GuzzleHttp\ClientInterface;
  * This class implements the search for the application default credentials as
  * described in the link.
  *
- * It provides two factory methods:
+ * It provides three factory methods:
  * - #get returns the computed credentials object
- * - #getFetcher returns an AuthTokenFetcher built from the credentials object
+ * - #getSubscriber returns an AuthTokenSubscriber built from the credentials object
+ * - #getMiddleware returns an AuthTokenMiddleware built from the credentials object
  *
  * This allows it to be used as follows with GuzzleHttp\Client:
  *
- *   use GuzzleHttp\Client;
  *   use Google\Auth\ApplicationDefaultCredentials;
+ *   use GuzzleHttp\Client;
+ *   use GuzzleHttp\HandlerStack;
+ *
+ *   $middleware = ApplicationDefaultCredentials::getMiddleware(
+ *       'https://www.googleapis.com/auth/taskqueue'
+ *   );
+ *   $stack = HandlerStack::create();
+ *   $stack->push($middleware);
  *
  *   $client = new Client([
- *      'base_url' => 'https://www.googleapis.com/taskqueue/v1beta2/projects/',
- *      'defaults' => ['auth' => 'google_auth']  // authorize all requests
+ *       'handler' => $stack,
+ *       'base_uri' => 'https://www.googleapis.com/taskqueue/v1beta2/projects/',
+ *       'auth' => 'google_auth' // authorize all requests
  *   ]);
- *   $fetcher = ApplicationDefaultCredentials::getFetcher(
- *       'https://www.googleapis.com/auth/taskqueue');
- *   $client->getEmitter()->attach($fetcher);
  *
  *   $res = $client->get('myproject/taskqueues/myqueue');
  */
 class ApplicationDefaultCredentials
 {
   /**
-   * Obtains an AuthTokenFetcher that uses the default FetchAuthTokenInterface
+   * Obtains an AuthTokenSubscriber that uses the default FetchAuthTokenInterface
    * implementation to use in this environment.
    *
    * If supplied, $scope is used to in creating the credentials instance if
@@ -60,20 +68,47 @@ class ApplicationDefaultCredentials
    *
    * @param string|array scope the scope of the access request, expressed
    *   either as an Array or as a space-delimited String.
-   * @param $client GuzzleHttp\ClientInterface optional client.
+   * @param callable $httpHandler callback which delivers psr7 request
+   * @param array $cacheConfig configuration for the cache when it's present
+   * @param object $cache an implementation of CacheInterface
+   *
+   * @throws DomainException if no implementation can be obtained.
+   */
+  public static function getSubscriber(
+    $scope = null,
+    callable $httpHandler = null,
+    array $cacheConfig = null,
+    CacheInterface $cache = null
+  ) {
+    $creds = self::getCredentials($scope, $httpHandler);
+
+    return new AuthTokenSubscriber($creds, $cacheConfig, $cache, $httpHandler);
+  }
+
+  /**
+   * Obtains an AuthTokenMiddleware that uses the default FetchAuthTokenInterface
+   * implementation to use in this environment.
+   *
+   * If supplied, $scope is used to in creating the credentials instance if
+   * this does not fallback to the compute engine defaults.
+   *
+   * @param string|array scope the scope of the access request, expressed
+   *   either as an Array or as a space-delimited String.
+   * @param callable $httpHandler callback which delivers psr7 request
    * @param cacheConfig configuration for the cache when it's present
    * @param object $cache an implementation of CacheInterface
    *
    * @throws DomainException if no implementation can be obtained.
    */
-  public static function getFetcher(
-      $scope = null,
-      ClientInterface $client = null,
-      array $cacheConfig = null,
-      CacheInterface $cache = null)
-  {
-    $creds = self::getCredentials($scope, $client);
-    return new AuthTokenFetcher($creds, $cacheConfig, $cache, $client);
+  public static function getMiddleware(
+    $scope = null,
+    callable $httpHandler = null,
+    array $cacheConfig = null,
+    CacheInterface $cache = null
+  ) {
+    $creds = self::getCredentials($scope, $httpHandler);
+
+    return new AuthTokenMiddleware($creds, $cacheConfig, $cache, $httpHandler);
   }
 
   /**
@@ -86,10 +121,10 @@ class ApplicationDefaultCredentials
    * @param string|array scope the scope of the access request, expressed
    *   either as an Array or as a space-delimited String.
    *
-   * @param $client GuzzleHttp\ClientInterface optional client.
+   * @param callable $httpHandler callback which delivers psr7 request
    * @throws DomainException if no implementation can be obtained.
    */
-  public static function getCredentials($scope = null, $client = null)
+  public static function getCredentials($scope = null, callable $httpHandler = null)
   {
     $creds = CredentialsLoader::fromEnv($scope);
     if (!is_null($creds)) {
@@ -102,7 +137,7 @@ class ApplicationDefaultCredentials
     if (AppIdentityCredentials::onAppEngine()) {
       return new AppIdentityCredentials($scope);
     }
-    if (GCECredentials::onGce($client)) {
+    if (GCECredentials::onGce($httpHandler)) {
       return new GCECredentials();
     }
     throw new \DomainException(self::notFound());

--- a/src/CacheInterface.php
+++ b/src/CacheInterface.php
@@ -48,5 +48,4 @@ interface CacheInterface
    * @param String $key
    */
   public function delete($key);
-
 }

--- a/src/CacheTrait.php
+++ b/src/CacheTrait.php
@@ -1,0 +1,68 @@
+<?php
+/*
+ * Copyright 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Auth;
+
+trait CacheTrait
+{
+  /**
+   * Gets the cached value if it is present in the cache when that is
+   * available.
+   */
+  private function getCachedValue()
+  {
+    if (is_null($this->cache)) {
+      return null;
+    }
+
+    if (isset($this->fetcher)) {
+      $fetcherKey = $this->fetcher->getCacheKey();
+    } else {
+      $fetcherKey = $this->getCacheKey();
+    }
+
+    if (is_null($fetcherKey)) {
+      return null;
+    }
+
+    $key = $this->cacheConfig['prefix'] . $fetcherKey;
+    return $this->cache->get($key, $this->cacheConfig['lifetime']);
+  }
+
+  /**
+   * Saves the value in the cache when that is available.
+   */
+  private function setCachedValue($v)
+  {
+    if (is_null($this->cache)) {
+      return;
+    }
+
+    if (isset($this->fetcher)) {
+      $fetcherKey = $this->fetcher->getCacheKey();
+    } else {
+      $fetcherKey = $this->getCacheKey();
+    }
+
+    if (is_null($fetcherKey)) {
+      return;
+    }
+    $key = $this->cacheConfig['prefix'] . $fetcherKey;
+    $this->cache->set($key, $v);
+  }
+}
+

--- a/src/Credentials/GCECredentials.php
+++ b/src/Credentials/GCECredentials.php
@@ -27,7 +27,7 @@ use GuzzleHttp\Psr7\Request;
 /**
  * GCECredentials supports authorization on Google Compute Engine.
  *
- * It can be used to authorize requests using the AuthTokenFetcher, but will
+ * It can be used to authorize requests using the AuthTokenMiddleware, but will
  * only succeed if being run on GCE:
  *
  *   use Google\Auth\Credentials\GCECredentials;
@@ -152,7 +152,13 @@ class GCECredentials extends CredentialsLoader
       )
     );
     $body = (string) $resp->getBody();
-    return json_decode($body, true);
+
+    // Assume it's JSON; if it's not throw an exception
+    if (null === $json = json_decode($body, true)) {
+      throw new \Exception('Invalid JSON response');
+    }
+
+    return $json;
   }
 
   /**

--- a/src/Credentials/IAMCredentials.php
+++ b/src/Credentials/IAMCredentials.php
@@ -15,9 +15,7 @@
  * limitations under the License.
  */
 
-namespace Google\Auth;
-
-use GuzzleHttp\ClientInterface;
+namespace Google\Auth\Credentials;
 
 /**
  * Authenticates requests using IAM credentials
@@ -50,9 +48,9 @@ class IAMCredentials
   }
 
   /**
-   * export a callback function which updates runtime metadata 
+   * export a callback function which updates runtime metadata
    *
-   * @return an updateMetadata function 
+   * @return an updateMetadata function
    */
   public function getUpdateMetadataFunc()
   {
@@ -62,18 +60,19 @@ class IAMCredentials
   /**
    * Updates metadata with the appropriate header metadata
    *
-   * @param $metadata array metadata hashmap
-   * @param $unusedAuthUri optional auth uri
-   * @param $unusedClient optional client interface
+   * @param array $metadata metadata hashmap
+   * @param string $unusedAuthUri optional auth uri
+   * @param callable $httpHandler callback which delivers psr7 request
    *        Note: this param is unused here, only included here for
    *        consistency with other credentials class
    *
    * @return array updated metadata hashmap
    */
-  public function updateMetadata($metadata,
-                                 $unusedAuthUri = null,
-                                 ClientInterface $unusedClient = null)
-  {
+  public function updateMetadata(
+    $metadata,
+    $unusedAuthUri = null,
+    callable $httpHandler = null
+  ) {
     $metadata_copy = $metadata;
     $metadata_copy[self::SELECTOR_KEY] = $this->selector;
     $metadata_copy[self::TOKEN_KEY] = $this->token;

--- a/src/Credentials/ServiceAccountCredentials.php
+++ b/src/Credentials/ServiceAccountCredentials.php
@@ -31,7 +31,7 @@ use GuzzleHttp\Psr7;
  * console, which should contain a private_key and client_email fields that it
  * uses.
  *
- * Use it with AuthTokenFetcher to authorize http requests:
+ * Use it with AuthTokenMiddleware to authorize http requests:
  *
  *   use Google\Auth\Credentials\ServiceAccountCredentials;
  *   use Google\Auth\Middleware\AuthTokenMiddleware;

--- a/src/Credentials/ServiceAccountCredentials.php
+++ b/src/Credentials/ServiceAccountCredentials.php
@@ -15,13 +15,11 @@
  * limitations under the License.
  */
 
-namespace Google\Auth;
+namespace Google\Auth\Credentials;
 
-use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Client;
-use GuzzleHttp\Stream\Stream;
-use GuzzleHttp\Exception\ClientException;
-use GuzzleHttp\Exception\ServerException;
+use Google\Auth\CredentialsLoader;
+use Google\Auth\OAuth2;
+use GuzzleHttp\Psr7;
 
 /**
  * ServiceAccountCredentials supports authorization using a Google service
@@ -35,19 +33,26 @@ use GuzzleHttp\Exception\ServerException;
  *
  * Use it with AuthTokenFetcher to authorize http requests:
  *
+ *   use Google\Auth\Credentials\ServiceAccountCredentials;
+ *   use Google\Auth\Middleware\AuthTokenMiddleware;
  *   use GuzzleHttp\Client;
- *   use Google\Auth\ServiceAccountCredentials;
- *   use Google\Auth\AuthTokenFetcher;
+ *   use GuzzleHttp\HandlerStack;
+ *   use GuzzleHttp\Psr7;
  *
- *   $stream = Stream::factory(get_file_contents(<my_key_file>));
+ *   $stream = Psr7\stream_for(file_get_contents(<my_key_file>));
  *   $sa = new ServiceAccountCredentials(
  *       'https://www.googleapis.com/auth/taskqueue',
- *        $stream);
+ *       $stream
+ *   );
+ *   $middleware = new AuthTokenMiddleware($sa);
+ *   $stack = HandlerStack::create();
+ *   $stack->push($middleware);
+ *
  *   $client = new Client([
- *      'base_url' => 'https://www.googleapis.com/taskqueue/v1beta2/projects/',
- *      'defaults' => ['auth' => 'google_auth']  // authorize all requests
+ *       'handler' => $stack,
+ *       'base_uri' => 'https://www.googleapis.com/taskqueue/v1beta2/projects/',
+ *       'auth' => 'google_auth' // authorize all requests
  *   ]);
- *   $client->getEmitter()->attach(new AuthTokenFetcher($sa));
  *
  *   $res = $client->get('myproject/taskqueues/myqueue');
  */
@@ -56,22 +61,25 @@ class ServiceAccountCredentials extends CredentialsLoader
   /**
    * Create a new ServiceAccountCredentials.
    *
-   * @param string|array scope the scope of the access request, expressed
+   * @param string|array $scope the scope of the access request, expressed
    *   either as an Array or as a space-delimited String.
    *
-   * @param array jsonKey JSON credentials.
+   * @param array $jsonKey JSON credentials.
    *
-   * @param string jsonKeyPath the path to a file containing JSON credentials.  If
+   * @param string $jsonKeyPath the path to a file containing JSON credentials.  If
    *   jsonKeyStream is set, it is ignored.
    *
-   * @param string sub an email address account to impersonate, in situations when
+   * @param string $sub an email address account to impersonate, in situations when
    *   the service account has been delegated domain wide access.
    */
-  public function __construct($scope, $jsonKey,
-                              $jsonKeyPath = null, $sub = null)
-  {
+  public function __construct(
+    $scope,
+    $jsonKey,
+    $jsonKeyPath = null,
+    $sub = null
+  ) {
     if (is_null($jsonKey)) {
-      $jsonKeyStream = Stream::factory(file_get_contents($jsonKeyPath));
+      $jsonKeyStream = Psr7\stream_for(file_get_contents($jsonKeyPath));
       $jsonKey = json_decode($jsonKeyStream->getContents(), true);
     }
     if (!array_key_exists('client_email', $jsonKey)) {
@@ -96,9 +104,9 @@ class ServiceAccountCredentials extends CredentialsLoader
   /**
    * Implements FetchAuthTokenInterface#fetchAuthToken.
    */
-  public function fetchAuthToken(ClientInterface $client = null)
+  public function fetchAuthToken(callable $httpHandler = null)
   {
-    return $this->auth->fetchAuthToken($client);
+    return $this->auth->fetchAuthToken($httpHandler);
   }
 
  /**
@@ -116,20 +124,21 @@ class ServiceAccountCredentials extends CredentialsLoader
   /**
    * Updates metadata with the authorization token
    *
-   * @param $metadata array metadata hashmap
-   * @param $authUri string optional auth uri
-   * @param $client optional client interface
+   * @param array $metadata metadata hashmap
+   * @param string $authUri optional auth uri
+   * @param callable $httpHandler callback which delivers psr7 request
    *
    * @return array updated metadata hashmap
    */
-  public function updateMetadata($metadata,
-                                 $authUri = null,
-                                 ClientInterface $client = null)
-  {
+  public function updateMetadata(
+    $metadata,
+    $authUri = null,
+    callable $httpHandler = null
+  ) {
     // scope exists. use oauth implementation
     $scope = $this->auth->getScope();
     if (!is_null($scope)) {
-      return parent::updateMetadata($metadata, $authUri, $client);
+      return parent::updateMetadata($metadata, $authUri, $httpHandler);
     }
 
     // no scope found. create jwt with the auth uri
@@ -138,11 +147,11 @@ class ServiceAccountCredentials extends CredentialsLoader
       'client_email' => $this->auth->getIssuer(),
     );
     $jwtCreds = new ServiceAccountJwtAccessCredentials($credJson);
-    return $jwtCreds->updateMetadata($metadata, $authUri, $client);
+    return $jwtCreds->updateMetadata($metadata, $authUri, $httpHandler);
   }
 
   /**
-   * @param string sub an email address account to impersonate, in situations when
+   * @param string $sub an email address account to impersonate, in situations when
    *   the service account has been delegated domain wide access.
    */
   public function setSub($sub)

--- a/src/Credentials/ServiceAccountJwtAccessCredentials.php
+++ b/src/Credentials/ServiceAccountJwtAccessCredentials.php
@@ -15,13 +15,10 @@
  * limitations under the License.
  */
 
-namespace Google\Auth;
+namespace Google\Auth\Credentials;
 
-use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Client;
-use GuzzleHttp\Stream\Stream;
-use GuzzleHttp\Exception\ClientException;
-use GuzzleHttp\Exception\ServerException;
+use Google\Auth\CredentialsLoader;
+use Google\Auth\OAuth2;
 
 /**
  * Authenticates requests using Google's Service Account credentials via
@@ -37,10 +34,9 @@ class ServiceAccountJwtAccessCredentials extends CredentialsLoader
   /**
    * Create a new ServiceAccountJwtAccessCredentials.
    *
-   * @param array jsonKey JSON credentials.
+   * @param array $jsonKey JSON credentials.
    */
-  public function __construct($jsonKey)
-  {
+  public function __construct(array $jsonKey) {
     if (!array_key_exists('client_email', $jsonKey)) {
       throw new \InvalidArgumentException(
           'json key is missing the client_email field');
@@ -60,28 +56,29 @@ class ServiceAccountJwtAccessCredentials extends CredentialsLoader
   /**
    * Updates metadata with the authorization token
    *
-   * @param $metadata array metadata hashmap
-   * @param $authUri string optional auth uri
-   * @param $client optional client interface
+   * @param array $metadata metadata hashmap
+   * @param string $authUri optional auth uri
+   * @param callable $httpHandler callback which delivers psr7 request
    *
    * @return array updated metadata hashmap
    */
-  public function updateMetadata($metadata,
-                                 $authUri = null,
-                                 ClientInterface $client = null)
-  {
+  public function updateMetadata(
+    $metadata,
+    $authUri = null,
+    callable $httpHandler = null
+  ) {
     if (empty($authUri)) {
       return $metadata;
     }
 
     $this->auth->setAudience($authUri);
-    return parent::updateMetadata($metadata, $authUri, $client);
+    return parent::updateMetadata($metadata, $authUri, $httpHandler);
   }
 
  /**
   * Implements FetchAuthTokenInterface#fetchAuthToken.
   */
-  public function fetchAuthToken(ClientInterface $unusedClient = null)
+  public function fetchAuthToken(callable $httpHandler = null)
   {
     $audience = $this->auth->getAudience();
     if (empty($audience)) {

--- a/src/Credentials/UserRefreshCredentials.php
+++ b/src/Credentials/UserRefreshCredentials.php
@@ -15,13 +15,11 @@
  * limitations under the License.
  */
 
-namespace Google\Auth;
+namespace Google\Auth\Credentials;
 
-use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Client;
-use GuzzleHttp\Stream\Stream;
-use GuzzleHttp\Exception\ClientException;
-use GuzzleHttp\Exception\ServerException;
+use Google\Auth\CredentialsLoader;
+use Google\Auth\OAuth2;
+use GuzzleHttp\Psr7;
 
 /**
  * Authenticates requests using User Refresh credentials.
@@ -39,19 +37,21 @@ class UserRefreshCredentials extends CredentialsLoader
   /**
    * Create a new UserRefreshCredentials.
    *
-   * @param string|array scope the scope of the access request, expressed
+   * @param string|array $scope the scope of the access request, expressed
    *   either as an Array or as a space-delimited String.
    *
-   * @param array jsonKey JSON credentials.
+   * @param array $jsonKey JSON credentials.
    *
-   * @param string jsonKeyPath the path to a file containing JSON credentials.  If
+   * @param string $jsonKeyPath the path to a file containing JSON credentials.  If
    *   jsonKeyStream is set, it is ignored.
    */
-  public function __construct($scope, $jsonKey,
-                              $jsonKeyPath = null)
-  {
+  public function __construct(
+    $scope,
+    $jsonKey,
+    $jsonKeyPath = null
+  ) {
     if (is_null($jsonKey)) {
-      $jsonKeyStream = Stream::factory(file_get_contents($jsonKeyPath));
+      $jsonKeyStream = Psr7\stream_for(file_get_contents($jsonKeyPath));
       $jsonKey = json_decode($jsonKeyStream->getContents(), true);
     }
     if (!array_key_exists('client_id', $jsonKey)) {
@@ -78,9 +78,9 @@ class UserRefreshCredentials extends CredentialsLoader
   /**
    * Implements FetchAuthTokenInterface#fetchAuthToken.
    */
-  public function fetchAuthToken(ClientInterface $client = null)
+  public function fetchAuthToken(callable $httpHandler = null)
   {
-    return $this->auth->fetchAuthToken($client);
+    return $this->auth->fetchAuthToken($httpHandler);
   }
 
  /**
@@ -90,5 +90,4 @@ class UserRefreshCredentials extends CredentialsLoader
   {
     return $this->auth->getClientId() . ':' . $this->auth->getCacheKey();
   }
-
 }

--- a/src/FetchAuthTokenInterface.php
+++ b/src/FetchAuthTokenInterface.php
@@ -17,8 +17,6 @@
 
 namespace Google\Auth;
 
-use GuzzleHttp\ClientInterface;
-
 /**
  * An interface implemented by objects that can fetch auth tokens.
  */
@@ -28,10 +26,10 @@ interface FetchAuthTokenInterface
  /**
   * Fetchs the auth tokens based on the current state.
   *
-  * @param $client GuzzleHttp\ClientInterface the optional client.
+  * @param callable $httpHandler callback which delivers psr7 request
   * @return array a hash of auth tokens
   */
-  public function fetchAuthToken(ClientInterface $client = null);
+  public function fetchAuthToken(callable $httpHandler = null);
 
 
  /**

--- a/src/HttpHandler/Guzzle5HttpHandler.php
+++ b/src/HttpHandler/Guzzle5HttpHandler.php
@@ -59,7 +59,7 @@ class Guzzle5HttpHandler
 
     return new Response(
       $response->getStatusCode(),
-      $response->getHeaders(),
+      $response->getHeaders() ?: [],
       $response->getBody(),
       $response->getProtocolVersion(),
       $response->getReasonPhrase()

--- a/src/HttpHandler/Guzzle5HttpHandler.php
+++ b/src/HttpHandler/Guzzle5HttpHandler.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Auth\HttpHandler;
+
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class Guzzle5HttpHandler
+{
+  /**
+   * @var ClientInterface
+   */
+  private $client;
+
+  /**
+   * @param ClientInterface $client
+   */
+  public function __construct(ClientInterface $client)
+  {
+    $this->client = $client;
+  }
+
+  /**
+   * Accepts a PSR-7 Request and an array of options and returns a PSR-7 response.
+   *
+   * @param RequestInterface $request
+   * @param array $options
+   * @return ResponseInterface
+   */
+  public function __invoke(RequestInterface $request, array $options = [])
+  {
+    $request = $this->client->createRequest(
+      $request->getMethod(),
+      $request->getUri(),
+      array_merge([
+        'headers' => $request->getHeaders(),
+        'body' => $request->getBody()
+      ], $options)
+    );
+
+    $response = $this->client->send($request);
+
+    return new Response(
+      $response->getStatusCode(),
+      $response->getHeaders(),
+      $response->getBody(),
+      $response->getProtocolVersion(),
+      $response->getReasonPhrase()
+    );
+  }
+}

--- a/src/HttpHandler/Guzzle6HttpHandler.php
+++ b/src/HttpHandler/Guzzle6HttpHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Google\Auth\HttpHandler;
+
+use GuzzleHttp\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class Guzzle6HttpHandler
+{
+  /**
+   * @var ClientInterface
+   */
+  private $client;
+
+  /**
+   * @param ClientInterface $client
+   */
+  public function __construct(ClientInterface $client)
+  {
+    $this->client = $client;
+  }
+
+  /**
+   * Accepts a PSR-7 request and an array of options and returns a PSR-7 response.
+   *
+   * @param RequestInterface $request
+   * @param array $options
+   * @return ResponseInterface
+   */
+  public function __invoke(RequestInterface $request, array $options = [])
+  {
+    return $this->client->send($request, $options);
+  }
+}

--- a/src/HttpHandler/HttpHandlerFactory.php
+++ b/src/HttpHandler/HttpHandlerFactory.php
@@ -30,10 +30,10 @@ class HttpHandlerFactory
    * @return Guzzle5HttpHandler|Guzzle6HttpHandler
    * @throws \Exception
    */
-  public static function build()
+  public static function build(ClientInterface $client = null)
   {
     $version = ClientInterface::VERSION;
-    $client = new Client();
+    $client = $client ?: new Client();
 
     switch ($version[0]) {
       case '5':

--- a/src/HttpHandler/HttpHandlerFactory.php
+++ b/src/HttpHandler/HttpHandlerFactory.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Auth\HttpHandler;
+
+use Google\Auth\HttpHandler\Guzzle5HttpHandler;
+use Google\Auth\HttpHandler\Guzzle6HttpHandler;
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+
+class HttpHandlerFactory
+{
+  /**
+   * Builds out a default http handler for the installed version of guzzle.
+   *
+   * @return Guzzle5HttpHandler|Guzzle6HttpHandler
+   * @throws \Exception
+   */
+  public static function build()
+  {
+    $version = ClientInterface::VERSION;
+    $client = new Client();
+
+    switch ($version[0]) {
+      case '5':
+          return new Guzzle5HttpHandler($client);
+      case '6':
+          return new Guzzle6HttpHandler($client);
+      default:
+          throw new \Exception('Version not supported');
+    }
+  }
+}

--- a/src/Middleware/AuthTokenMiddleware.php
+++ b/src/Middleware/AuthTokenMiddleware.php
@@ -1,0 +1,142 @@
+<?php
+/*
+ * Copyright 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Auth\Middleware;
+
+use Google\Auth\CacheInterface;
+use Google\Auth\CacheTrait;
+use Google\Auth\FetchAuthTokenInterface;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * AuthTokenMiddleware is a Guzzle Middleware that adds an Authorization header
+ * provided by an object implementing FetchAuthTokenInterface.
+ *
+ * The FetchAuthTokenInterface#fetchAuthToken is used to obtain a hash; one of
+ * the values value in that hash is added as the authorization header.
+ *
+ * Requests will be accessed with the authorization header:
+ *
+ * 'Authorization' 'Bearer <value of auth_token>'
+ */
+class AuthTokenMiddleware
+{
+  use CacheTrait;
+
+  const DEFAULT_CACHE_LIFETIME = 1500;
+
+  /** @var An implementation of CacheInterface */
+  private $cache;
+
+  /** @var callback */
+  private $httpHandler;
+
+  /** @var An implementation of FetchAuthTokenInterface */
+  private $fetcher;
+
+  /** @var cache configuration */
+  private $cacheConfig;
+
+  /**
+   * Creates a new AuthTokenMiddleware.
+   *
+   * @param FetchAuthTokenInterface $fetcher is used to fetch the auth token
+   * @param array $cacheConfig configures the cache
+   * @param CacheInterface $cache (optional) caches the token.
+   * @param callable $httpHandler (optional) callback which delivers psr7 request
+   */
+  public function __construct(
+    FetchAuthTokenInterface $fetcher,
+    array $cacheConfig = null,
+    CacheInterface $cache = null,
+    callable $httpHandler = null
+  ) {
+    $this->fetcher = $fetcher;
+    $this->httpHandler = $httpHandler;
+    if (!is_null($cache)) {
+      $this->cache = $cache;
+      $this->cacheConfig = array_merge([
+        'lifetime' => self::DEFAULT_CACHE_LIFETIME,
+        'prefix'   => ''
+      ], $cacheConfig);
+    }
+  }
+
+  /**
+   * Updates the request with an Authorization header when auth is 'google_auth'.
+   *
+   *   use Google\Auth\Middleware\AuthTokenMiddleware;
+   *   use Google\Auth\OAuth2;
+   *   use GuzzleHttp\Client;
+   *   use GuzzleHttp\HandlerStack;
+   *
+   *   $config = [..<oauth config param>.];
+   *   $oauth2 = new OAuth2($config)
+   *   $middleware = new AuthTokenMiddleware(
+   *       $oauth2,
+   *       ['prefix' => 'OAuth2::'],
+   *       $cache = new Memcache()
+   *   );
+   *   $stack = HandlerStack::create();
+   *   $stack->push($middleware);
+   *
+   *   $client = new Client([
+   *       'handler' => $stack,
+   *       'base_uri' => 'https://www.googleapis.com/taskqueue/v1beta2/projects/',
+   *       'auth' => 'google_auth' // authorize all requests
+   *   ]);
+   *
+   *   $res = $client->get('myproject/taskqueues/myqueue');
+   */
+  public function __invoke(callable $handler)
+  {
+    return function (RequestInterface $request, array $options) use ($handler) {
+      // Requests using "auth"="google_auth" will be authorized.
+      if (!isset($options['auth']) || $options['auth'] !== 'google_auth') {
+        return $handler($request, $options);
+      }
+
+      $request = $request->withHeader('Authorization', 'Bearer ' . $this->fetchToken());
+      return $handler($request, $options);
+    };
+  }
+
+  /**
+   * Determine if token is available in the cache, if not call fetcher to
+   * fetch it.
+   *
+   * @return string
+   */
+  private function fetchToken()
+  {
+    // TODO: correct caching; update the call to setCachedValue to set the expiry
+    // to the value returned with the auth token.
+    //
+    // TODO: correct caching; enable the cache to be cleared.
+    $cached = $this->getCachedValue();
+    if (!empty($cached)) {
+      return $cached;
+    }
+
+    $auth_tokens = $this->fetcher->fetchAuthToken($this->httpHandler);
+
+    if (array_key_exists('access_token', $auth_tokens)) {
+      $this->setCachedValue($auth_tokens['access_token']);
+      return $auth_tokens['access_token'];
+    }
+  }
+}

--- a/src/Middleware/ScopedAccessTokenMiddleware.php
+++ b/src/Middleware/ScopedAccessTokenMiddleware.php
@@ -1,0 +1,160 @@
+<?php
+/*
+ * Copyright 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Auth\Middleware;
+
+use Google\Auth\CacheInterface;
+use Google\Auth\CacheTrait;
+use Google\Auth\FetchAuthTokenInterface;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * ScopedAccessTokenMiddleware is a Guzzle Middleware that adds an Authorization
+ * header provided by a closure.
+ *
+ * The closure returns an access token, taking the scope, either a single
+ * string or an array of strings, as its value.  If provided, a cache will be
+ * used to preserve the access token for a given lifetime.
+ *
+ * Requests will be accessed with the authorization header:
+ *
+ * 'Authorization' 'Bearer <value of auth_token>'
+ */
+class ScopedAccessTokenMiddleware
+{
+  use CacheTrait;
+
+  const DEFAULT_CACHE_LIFETIME = 1500;
+
+  /** @var An implementation of CacheInterface */
+  private $cache;
+
+  /** @var callback */
+  private $httpHandler;
+
+  /** @var An implementation of FetchAuthTokenInterface */
+  private $fetcher;
+
+  /** @var cache configuration */
+  private $cacheConfig;
+
+  /**
+   * Creates a new ScopedAccessTokenMiddleware.
+   *
+   * @param callable $tokenFunc a token generator function
+   * @param array|string $scopes the token authentication scopes
+   * @param array $cacheConfig configuration for the cache when it's present
+   * @param CacheInterface $cache an implementation of CacheInterface
+   */
+  public function __construct(
+    callable $tokenFunc,
+    $scopes,
+    array $cacheConfig = null,
+    CacheInterface $cache = null
+  ) {
+    $this->tokenFunc = $tokenFunc;
+    if (!(is_string($scopes) || is_array($scopes))) {
+      throw new \InvalidArgumentException(
+          'wants scope should be string or array');
+    }
+    $this->scopes = $scopes;
+
+    if (!is_null($cache)) {
+      $this->cache = $cache;
+      $this->cacheConfig = array_merge([
+        'lifetime' => self::DEFAULT_CACHE_LIFETIME,
+        'prefix'   => ''
+      ], $cacheConfig);
+    }
+  }
+
+  /**
+   * Updates the request with an Authorization header when auth is 'scoped'.
+   *
+   *   E.g this could be used to authenticate using the AppEngine
+   *   AppIdentityService.
+   *
+   *   use google\appengine\api\app_identity\AppIdentityService;
+   *   use Google\Auth\Middleware\ScopedAccessTokenMiddleware;
+   *   use GuzzleHttp\Client;
+   *   use GuzzleHttp\HandlerStack;
+   *
+   *   $scope = 'https://www.googleapis.com/auth/taskqueue'
+   *   $middleware = new ScopedAccessTokenMiddleware(
+   *       'AppIdentityService::getAccessToken',
+   *       $scope,
+   *       [ 'prefix' => 'Google\Auth\ScopedAccessToken::' ],
+   *       $cache = new Memcache()
+   *   );
+   *   $stack = HandlerStack::create();
+   *   $stack->push($middleware);
+   *
+   *   $client = new Client([
+   *       'handler' => $stack,
+   *       'base_url' => 'https://www.googleapis.com/taskqueue/v1beta2/projects/',
+   *       'auth' => 'google_auth' // authorize all requests
+   *   ]);
+   *
+   *   $res = $client->get('myproject/taskqueues/myqueue');
+   */
+  public function __invoke(callable $handler)
+  {
+    return function (RequestInterface $request, array $options) use ($handler) {
+      // Requests using "auth"="scoped" will be authorized.
+      if (!isset($options['auth']) || $options['auth'] !== 'scoped') {
+        return $handler($request, $options);
+      }
+
+      $request = $request->withHeader('Authorization', 'Bearer ' . $this->fetchToken());
+      return $handler($request, $options);
+    };
+  }
+
+  /**
+   * @return string
+   */
+  private function getCacheKey()
+  {
+    $key = null;
+
+    if (is_string($this->scopes)) {
+      $key .= $this->scopes;
+    } else if (is_array($this->scopes)) {
+      $key .= implode(":", $this->scopes);
+    }
+    return $key;
+  }
+
+  /**
+   * Determine if token is available in the cache, if not call tokenFunc to
+   * fetch it.
+   *
+   * @return string
+   */
+  private function fetchToken()
+  {
+    $cached = $this->getCachedValue();
+
+    if (!empty($cached)) {
+      return $cached;
+    }
+
+    $token = call_user_func($this->tokenFunc, $this->scopes);
+    $this->setCachedValue($token);
+    return $token;
+  }
+}

--- a/src/Middleware/SimpleMiddleware.php
+++ b/src/Middleware/SimpleMiddleware.php
@@ -1,0 +1,84 @@
+<?php
+/*
+ * Copyright 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Auth\Middleware;
+
+use GuzzleHttp\Psr7;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * SimpleMiddleware is a Guzzle Middleware that implements Google's Simple API
+ * access.
+ *
+ * Requests are accessed using the Simple API access developer key.
+ */
+class SimpleMiddleware
+{
+  /** @var configuration */
+  private $config;
+
+  /**
+   * Create a new Simple plugin.
+   *
+   * The configuration array expects one option
+   * - key: required, otherwise InvalidArgumentException is thrown
+   *
+   * @param array $config Configuration array
+   */
+  public function __construct(array $config)
+  {
+    if (!isset($config['key'])) {
+      throw new \InvalidArgumentException('requires a key to have been set');
+    }
+
+    $this->config = array_merge(['key' => null], $config);
+  }
+
+  /**
+   * Updates the request query with the developer key if auth is set to simple
+   *
+   *   use Google\Auth\Middleware\SimpleMiddleware;
+   *   use GuzzleHttp\Client;
+   *   use GuzzleHttp\HandlerStack;
+   *
+   *   $my_key = 'is not the same as yours';
+   *   $middleware = new SimpleMiddleware(['key' => $my_key]);
+   *   $stack = HandlerStack::create();
+   *   $stack->push($middleware);
+   *
+   *   $client = new Client([
+   *       'handler' => $stack,
+   *       'base_uri' => 'https://www.googleapis.com/discovery/v1/',
+   *       'auth' => 'simple'
+   *   ]);
+   *
+   *   $res = $client->get('drive/v2/rest');
+   */
+  public function __invoke(callable $handler)
+  {
+    return function (RequestInterface $request, array $options) use ($handler) {
+      // Requests using "auth"="scoped" will be authorized.
+      if (!isset($options['auth']) || $options['auth'] !== 'simple') {
+        return $handler($request, $options);
+      }
+
+      $uri = $request->getUri()->withQuery(Psr7\build_query($this->config));
+      $request = $request->withUri($uri);
+      return $handler($request, $options);
+    };
+  }
+}

--- a/src/OAuth2.php
+++ b/src/OAuth2.php
@@ -17,12 +17,13 @@
 
 namespace Google\Auth;
 
-use GuzzleHttp\Client;
-use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Collection;
-use GuzzleHttp\Query;
-use GuzzleHttp\Message\ResponseInterface;
-use GuzzleHttp\Url;
+use Google\Auth\FetchAuthTokenInterface;
+use Google\Auth\HttpHandler\HttpHandlerFactory;
+use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Request;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\UriInterface;
 
 /**
  * OAuth2 supports authentication by OAuth2 2-legged flows.
@@ -262,28 +263,44 @@ class OAuth2 implements FetchAuthTokenInterface
    */
   public function __construct(array $config)
   {
-    $opts = Collection::fromConfig($config, [
-        'expiry' => self::DEFAULT_EXPIRY_MINUTES,
-        'extensionParams' => []
-    ], []);
-    $this->setAuthorizationUri($opts->get('authorizationUri'));
-    $this->setRedirectUri($opts->get('redirectUri'));
-    $this->setTokenCredentialUri($opts->get('tokenCredentialUri'));
-    $this->setState($opts->get('state'));
-    $this->setUsername($opts->get('username'));
-    $this->setPassword($opts->get('password'));
-    $this->setClientId($opts->get('clientId'));
-    $this->setClientSecret($opts->get('clientSecret'));
-    $this->setIssuer($opts->get('issuer'));
-    $this->setPrincipal($opts->get('principal'));
-    $this->setSub($opts->get('sub'));
-    $this->setExpiry($opts->get('expiry'));
-    $this->setAudience($opts->get('audience'));
-    $this->setSigningKey($opts->get('signingKey'));
-    $this->setSigningAlgorithm($opts->get('signingAlgorithm'));
-    $this->setScope($opts->get('scope'));
-    $this->setExtensionParams($opts->get('extensionParams'));
-    $this->updateToken($config);
+    $opts = array_merge([
+      'expiry' => self::DEFAULT_EXPIRY_MINUTES,
+      'extensionParams' => [],
+      'authorizationUri' => null,
+      'redirectUri' => null,
+      'tokenCredentialUri' => null,
+      'state' => null,
+      'username' => null,
+      'password' => null,
+      'clientId' => null,
+      'clientSecret' => null,
+      'issuer' => null,
+      'principal' => null,
+      'sub' => null,
+      'audience' => null,
+      'signingKey' => null,
+      'signingAlgorithm' => null,
+      'scope' => null
+    ], $config);
+
+    $this->setAuthorizationUri($opts['authorizationUri']);
+    $this->setRedirectUri($opts['redirectUri']);
+    $this->setTokenCredentialUri($opts['tokenCredentialUri']);
+    $this->setState($opts['state']);
+    $this->setUsername($opts['username']);
+    $this->setPassword($opts['password']);
+    $this->setClientId($opts['clientId']);
+    $this->setClientSecret($opts['clientSecret']);
+    $this->setIssuer($opts['issuer']);
+    $this->setPrincipal($opts['principal']);
+    $this->setSub($opts['sub']);
+    $this->setExpiry($opts['expiry']);
+    $this->setAudience($opts['audience']);
+    $this->setSigningKey($opts['signingKey']);
+    $this->setSigningAlgorithm($opts['signingAlgorithm']);
+    $this->setScope($opts['scope']);
+    $this->setExtensionParams($opts['extensionParams']);
+    $this->updateToken($opts);
   }
 
  /**
@@ -320,7 +337,7 @@ class OAuth2 implements FetchAuthTokenInterface
   *
   * @param $config array optional configuration parameters
   */
-  public function toJwt(array $config = null)
+  public function toJwt(array $config = [])
   {
     if (is_null($this->getSigningKey())) {
       throw new \DomainException('No signing key available');
@@ -329,17 +346,16 @@ class OAuth2 implements FetchAuthTokenInterface
       throw new \DomainException('No signing algorithm specified');
     }
     $now = time();
-    if (is_null($config)) {
-      $config = [];
-    }
-    $opts = Collection::fromConfig($config, [
-        'skew' => self::DEFAULT_SKEW,
-    ], []);
+
+    $opts = array_merge([
+      'skew' => self::DEFAULT_SKEW
+    ], $config);
+
     $assertion = [
         'iss' => $this->getIssuer(),
         'aud' => $this->getAudience(),
         'exp' => ($now + $this->getExpiry()),
-        'iat' => ($now - $opts->get('skew'))
+        'iat' => ($now - $opts['skew'])
     ];
     foreach ($assertion as $k => $v) {
       if (is_null($v)) {
@@ -362,18 +378,15 @@ class OAuth2 implements FetchAuthTokenInterface
  /**
   * Generates a request for token credentials.
   *
-  * @param $client GuzzleHttp\ClientInterface the optional client.
-  * @return GuzzleHttp\RequestInterface the authorization Url.
+  * @return RequestInterface the authorization Url.
   */
-  public function generateCredentialsRequest(ClientInterface $client = null)
+  public function generateCredentialsRequest()
   {
     $uri = $this->getTokenCredentialUri();
     if (is_null($uri)) {
       throw new \DomainException('No token credential URI was set.');
     }
-    if (is_null($client)) {
-      $client = new Client();
-    }
+
     $grantType = $this->getGrantType();
     $params = array('grant_type' => $grantType);
     switch($grantType) {
@@ -406,26 +419,34 @@ class OAuth2 implements FetchAuthTokenInterface
         }
         $params = array_merge($params, $this->getExtensionParams());
     }
-    $request = $client->createRequest('POST', $uri);
-    $request->addHeader('Cache-Control', 'no-store');
-    $request->addHeader('Content-Type', 'application/x-www-form-urlencoded');
-    $request->getBody()->replaceFields($params);
-    return $request;
+
+    $headers = [
+      'Cache-Control' => 'no-store',
+      'Content-Type' => 'application/x-www-form-urlencoded'
+    ];
+
+    return new Request(
+      'POST',
+      $uri,
+      $headers,
+      Psr7\build_query($params)
+    );
   }
 
  /**
   * Fetchs the auth tokens based on the current state.
   *
-  * @param $client GuzzleHttp\ClientInterface the optional client.
+  * @param callable $httpHandler callback which delivers psr7 request
   * @return array the response
   */
-  public function fetchAuthToken(ClientInterface $client = null)
+  public function fetchAuthToken(callable $httpHandler = null)
   {
-    if (is_null($client)) {
-      $client = new Client();
+    if (is_null($httpHandler)) {
+      $httpHandler = HttpHandlerFactory::build();
     }
-    $resp = $client->send($this->generateCredentialsRequest($client));
-    $creds = $this->parseTokenResponse($resp);
+
+    $response = $httpHandler($this->generateCredentialsRequest());
+    $creds = $this->parseTokenResponse($response);
     $this->updateToken($creds);
     return $creds;
   }
@@ -451,21 +472,21 @@ class OAuth2 implements FetchAuthTokenInterface
  /**
   * Parses the fetched tokens.
   *
-  * @param $resp GuzzleHttp\Message\ReponseInterface the response.
+  * @param $resp ReponseInterface the response.
   * @return array the tokens parsed from the response body.
   */
   public function parseTokenResponse(ResponseInterface $resp)
   {
-    $body = $resp->getBody()->getContents();
+    $body = (string) $resp->getBody();
     if ($resp->hasHeader('Content-Type') &&
-        $resp->getHeader('Content-Type') == 'application/x-www-form-urlencoded') {
+        $resp->getHeaderLine('Content-Type') == 'application/x-www-form-urlencoded') {
       $res = array();
       parse_str($body, $res);
       return $res;
     } else {
       // Assume it's JSON; if it's not there needs to be an exception, so
       // we use the json decode exception instead of adding a new one.
-      return $resp->json();
+      return json_decode($body, true);
     }
   }
 
@@ -503,65 +524,75 @@ class OAuth2 implements FetchAuthTokenInterface
   */
   public function updateToken(array $config)
   {
-    $opts = Collection::fromConfig($config, [
-        'extensionParams' => []
-    ], []);
-    $this->setExpiresAt($opts->get('expires'));
-    $this->setExpiresAt($opts->get('expires_at'));
-    $this->setExpiresIn($opts->get('expires_in'));
+    $opts = array_merge([
+      'extensionParams' => [],
+      'refresh_token' => null,
+      'access_token' => null,
+      'id_token' => null,
+      'expires' => null,
+      'expires_in' => null,
+      'expires_at' => null,
+      'issued_at' => null
+    ], $config);
+
+    $this->setExpiresAt($opts['expires']);
+    $this->setExpiresAt($opts['expires_at']);
+    $this->setExpiresIn($opts['expires_in']);
     // By default, the token is issued at `Time.now` when `expiresIn` is set,
     // but this can be used to supply a more precise time.
-    $this->setIssuedAt($opts->get('issued_at'));
+    $this->setIssuedAt($opts['issued_at']);
 
-    $this->setAccessToken($opts->get('access_token'));
-    $this->setIdToken($opts->get('id_token'));
-    $this->setRefreshToken($opts->get('refresh_token'));
+    $this->setAccessToken($opts['access_token']);
+    $this->setIdToken($opts['id_token']);
+    $this->setRefreshToken($opts['refresh_token']);
   }
 
   /**
    * Builds the authorization Uri that the user should be redirected to.
    *
    * @param $config configuration options that customize the return url
-   * @return GuzzleHttp::Url the authorization Url.
+   * @return UriInterface the authorization Url.
+   * @throws InvalidArgumentException
    */
-  public function buildFullAuthorizationUri(array $config = null)
+  public function buildFullAuthorizationUri(array $config = [])
   {
     if (is_null($this->getAuthorizationUri())) {
       throw new \InvalidArgumentException(
           'requires an authorizationUri to have been set');
     }
-    $defaults = [
+
+    $params = array_merge([
         'response_type' => 'code',
         'access_type' => 'offline',
         'client_id' => $this->clientId,
         'redirect_uri' => $this->redirectUri,
         'state' => $this->state,
-        'scope' => $this->getScope()
-    ];
-    $params = new Collection($defaults);
-    if (!is_null($config)) {
-      $params = Collection::fromConfig($config, $defaults, []);
-    }
+        'scope' => $this->getScope(),
+        'prompt' => null,
+        'approval_prompt' => null
+    ], $config);
 
     // Validate the auth_params
-    if (is_null($params->get('client_id'))) {
+    if (is_null($params['client_id'])) {
       throw new \InvalidArgumentException(
           'missing the required client identifier');
     }
-    if (is_null($params->get('redirect_uri'))) {
+    if (is_null($params['redirect_uri'])) {
       throw new \InvalidArgumentException('missing the required redirect URI');
     }
-    if ($params->hasKey('prompt') && $params->hasKey('approval_prompt')) {
+    if ($params['prompt'] && $params['approval_prompt']) {
       throw new \InvalidArgumentException(
           'prompt and approval_prompt are mutually exclusive');
     }
 
     // Construct the uri object; return it if it is valid.
     $result = clone $this->authorizationUri;
-    if (is_string($result)) {
-      $result = Url::fromString($this->getAuthorizationUri());
-    }
-    $result->getQuery()->merge($params);
+    $existingParams = Psr7\parse_query($result->getQuery());
+
+    $result = $result->withQuery(
+      Psr7\build_query(array_merge($existingParams, $params))
+    );
+
     if ($result->getScheme() != 'https') {
       throw new \InvalidArgumentException(
           'Authorization endpoint must be protected by TLS');
@@ -698,7 +729,7 @@ class OAuth2 implements FetchAuthTokenInterface
     if (in_array($gt, self::$knownGrantTypes)) {
       $this->grantType = $gt;
     } else {
-      $this->grantType = Url::fromString($gt);
+      $this->grantType = Psr7\uri_for($gt);
     }
   }
 
@@ -1055,20 +1086,18 @@ class OAuth2 implements FetchAuthTokenInterface
     $this->refreshToken = $refreshToken;
   }
 
+  /**
+   * @todo handle uri as array
+   * @param string $uri
+   * @return null|UriInterface
+   */
   private function coerceUri($uri)
   {
     if (is_null($uri)) {
       return null;
-    } else if (is_string($uri)) {
-      return Url::fromString($uri);
-    } else if (is_array($uri)) {
-      return Url::buildUrl($uri);
-    } else if (get_class($uri) == 'GuzzleHttp\Url') {
-      return $uri;
-    } else {
-      throw new \InvalidArgumentException(
-          'unexpected type for a uri: ' . get_class($uri));
     }
+
+    return Psr7\uri_for($uri);
   }
 
   private function jwtDecode($idToken, $publicKey, $allowedAlgs)
@@ -1093,8 +1122,11 @@ class OAuth2 implements FetchAuthTokenInterface
   /**
    * Determines if the URI is absolute based on its scheme and host or path
    * (RFC 3986)
+   *
+   * @param UriInterface $u
+   * @return bool
    */
-  private function isAbsoluteUri($u)
+  private function isAbsoluteUri(UriInterface $u)
   {
     return $u->getScheme() && ($u->getHost() || $u->getPath());
   }

--- a/src/Subscriber/SimpleSubscriber.php
+++ b/src/Subscriber/SimpleSubscriber.php
@@ -15,19 +15,19 @@
  * limitations under the License.
  */
 
-namespace Google\Auth;
+namespace Google\Auth\Subscriber;
 
-use GuzzleHttp\Collection;
+use GuzzleHttp\Event\BeforeEvent;
 use GuzzleHttp\Event\RequestEvents;
 use GuzzleHttp\Event\SubscriberInterface;
-use GuzzleHttp\Event\BeforeEvent;
 
 /**
- * Simple is a Guzzle Subscriber that implements Google's Simple API access.
+ * SimpleSubscriber is a Guzzle Subscriber that implements Google's Simple API
+ * access.
  *
  * Requests are accessed using the Simple API access developer key.
  */
-class Simple implements SubscriberInterface
+class SimpleSubscriber implements SubscriberInterface
 {
   /** @var configuration */
   private $config;
@@ -42,7 +42,11 @@ class Simple implements SubscriberInterface
    */
   public function __construct(array $config)
   {
-    $this->config = Collection::fromConfig($config, [], ['key']);
+    if (!isset($config['key'])) {
+      throw new \InvalidArgumentException('requires a key to have been set');
+    }
+
+    $this->config = array_merge([], $config);
   }
 
   /* Implements SubscriberInterface */
@@ -54,15 +58,17 @@ class Simple implements SubscriberInterface
   /**
    * Updates the request query with the developer key if auth is set to simple
    *
+   *   use Google\Auth\Subscriber\SimpleSubscriber;
    *   use GuzzleHttp\Client;
-   *   use Google\Auth\Simple;
    *
    *   $my_key = 'is not the same as yours';
-   *   $simple = new Simple(['key' => $my_key]);
+   *   $subscriber = new SimpleSubscriber(['key' => $my_key]);
+   *
    *   $client = new Client([
    *      'base_url' => 'https://www.googleapis.com/discovery/v1/',
    *      'defaults' => ['auth' => 'simple']
    *   ]);
+   *   $client->getEmitter()->attach($subscriber);
    *
    *   $res = $client->get('drive/v2/rest');
    */

--- a/tests/ApplicationDefaultCredentialsTest.php
+++ b/tests/ApplicationDefaultCredentialsTest.php
@@ -20,10 +20,7 @@ namespace Google\Auth\Tests;
 use Google\Auth\ApplicationDefaultCredentials;
 use Google\Auth\Credentials\GCECredentials;
 use Google\Auth\Credentials\ServiceAccountCredentials;
-use Google\Auth\HttpHandler\Guzzle6HttpHandler;
-use GuzzleHttp\Client;
 use GuzzleHttp\Psr7;
-use GuzzleHttp\Psr7\Response;
 
 class ADCGetTest extends \PHPUnit_Framework_TestCase
 {
@@ -180,15 +177,13 @@ class ADCGetMiddlewareTest extends \PHPUnit_Framework_TestCase
 }
 
 // @todo consider a way to DRY this and above class up
-class ADCGetSubscriberTest extends \PHPUnit_Framework_TestCase
+class ADCGetSubscriberTest extends BaseTest
 {
   private $originalHome;
 
   protected function setUp()
   {
-    if (!interface_exists('GuzzleHttp\Event\SubscriberInterface')) {
-      $this->markTestSkipped();
-    }
+    $this->onlyGuzzle5();
 
     $this->originalHome = getenv('HOME');
   }

--- a/tests/ApplicationDefaultCredentialsTest.php
+++ b/tests/ApplicationDefaultCredentialsTest.php
@@ -18,12 +18,12 @@
 namespace Google\Auth\Tests;
 
 use Google\Auth\ApplicationDefaultCredentials;
-use Google\Auth\GCECredentials;
-use Google\Auth\ServiceAccountCredentials;
+use Google\Auth\Credentials\GCECredentials;
+use Google\Auth\Credentials\ServiceAccountCredentials;
+use Google\Auth\HttpHandler\Guzzle6HttpHandler;
 use GuzzleHttp\Client;
-use GuzzleHttp\Message\Response;
-use GuzzleHttp\Stream\Stream;
-use GuzzleHttp\Subscriber\Mock;
+use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Response;
 
 class ADCGetTest extends \PHPUnit_Framework_TestCase
 {
@@ -75,34 +75,36 @@ class ADCGetTest extends \PHPUnit_Framework_TestCase
   public function testFailsIfNotOnGceAndNoDefaultFileFound()
   {
     putenv('HOME=' . __DIR__ . '/not_exist_fixtures');
-    $client = new Client();
     // simulate not being GCE by return 500
-    $client->getEmitter()->attach(new Mock([new Response(500)]));
-    ApplicationDefaultCredentials::getCredentials('a scope', $client);
+    $httpHandler = getHandler([
+      buildResponse(500)
+    ]);
+
+    ApplicationDefaultCredentials::getCredentials('a scope', $httpHandler);
   }
 
   public function testSuccedsIfNoDefaultFilesButIsOnGCE()
   {
-    $client = new Client();
-    // simulate the response from GCE.
     $wantedTokens = [
         'access_token' => '1/abdef1234567890',
         'expires_in' => '57',
         'token_type' => 'Bearer',
     ];
     $jsonTokens = json_encode($wantedTokens);
-    $plugin = new Mock([
-        new Response(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
-        new Response(200, [], Stream::factory($jsonTokens)),
+
+    // simulate the response from GCE.
+    $httpHandler = getHandler([
+      buildResponse(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
+      buildResponse(200, [], Psr7\stream_for($jsonTokens))
     ]);
-    $client->getEmitter()->attach($plugin);
+
     $this->assertNotNull(
-        ApplicationDefaultCredentials::getCredentials('a scope', $client)
+        ApplicationDefaultCredentials::getCredentials('a scope', $httpHandler)
     );
   }
 }
 
-class ADCGetFetcherTest extends \PHPUnit_Framework_TestCase
+class ADCGetMiddlewareTest extends \PHPUnit_Framework_TestCase
 {
   private $originalHome;
 
@@ -126,20 +128,21 @@ class ADCGetFetcherTest extends \PHPUnit_Framework_TestCase
   {
     $keyFile = __DIR__ . '/fixtures' . '/does-not-exist-private.json';
     putenv(ServiceAccountCredentials::ENV_VAR . '=' . $keyFile);
-    ApplicationDefaultCredentials::getFetcher('a scope');
+    ApplicationDefaultCredentials::getMiddleware('a scope');
   }
 
   public function testLoadsOKIfEnvSpecifiedIsValid()
   {
     $keyFile = __DIR__ . '/fixtures' . '/private.json';
     putenv(ServiceAccountCredentials::ENV_VAR . '=' . $keyFile);
-    $this->assertNotNull(ApplicationDefaultCredentials::getFetcher('a scope'));
+    $this->assertNotNull(ApplicationDefaultCredentials::getMiddleware('a scope'));
   }
 
   public function testLoadsDefaultFileIfPresentAndEnvVarIsNotSet()
   {
     putenv('HOME=' . __DIR__ . '/fixtures');
-    $this->assertNotNull(ApplicationDefaultCredentials::getFetcher('a scope'));
+    $this->assertNotNull(ApplicationDefaultCredentials::getMiddleware('a scope'));
+
   }
 
   /**
@@ -148,28 +151,110 @@ class ADCGetFetcherTest extends \PHPUnit_Framework_TestCase
   public function testFailsIfNotOnGceAndNoDefaultFileFound()
   {
     putenv('HOME=' . __DIR__ . '/not_exist_fixtures');
-    $client = new Client();
+
     // simulate not being GCE by return 500
-    $client->getEmitter()->attach(new Mock([new Response(500)]));
-    ApplicationDefaultCredentials::getFetcher('a scope', $client);
+    $httpHandler = getHandler([
+      buildResponse(500)
+    ]);
+
+    ApplicationDefaultCredentials::getMiddleware('a scope', $httpHandler);
   }
 
   public function testSuccedsIfNoDefaultFilesButIsOnGCE()
   {
-    $client = new Client();
-    // simulate the response from GCE.
     $wantedTokens = [
         'access_token' => '1/abdef1234567890',
         'expires_in' => '57',
         'token_type' => 'Bearer',
     ];
     $jsonTokens = json_encode($wantedTokens);
-    $plugin = new Mock([
-        new Response(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
-        new Response(200, [], Stream::factory($jsonTokens)),
+
+    // simulate the response from GCE.
+    $httpHandler = getHandler([
+      buildResponse(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
+      buildResponse(200, [], Psr7\stream_for($jsonTokens))
     ]);
-    $client->getEmitter()->attach($plugin);
-    $this->assertNotNull(
-        ApplicationDefaultCredentials::getFetcher('a scope', $client));
+
+    $this->assertNotNull(ApplicationDefaultCredentials::getMiddleware('a scope', $httpHandler));
+  }
+}
+
+// @todo consider a way to DRY this and above class up
+class ADCGetSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+  private $originalHome;
+
+  protected function setUp()
+  {
+    if (!interface_exists('GuzzleHttp\Event\SubscriberInterface')) {
+      $this->markTestSkipped();
+    }
+
+    $this->originalHome = getenv('HOME');
+  }
+
+  protected function tearDown()
+  {
+    if ($this->originalHome != getenv('HOME')) {
+      putenv('HOME=' . $this->originalHome);
+    }
+    putenv(ServiceAccountCredentials::ENV_VAR);  // removes it if assigned
+  }
+
+  /**
+   * @expectedException DomainException
+   */
+  public function testIsFailsEnvSpecifiesNonExistentFile()
+  {
+    $keyFile = __DIR__ . '/fixtures' . '/does-not-exist-private.json';
+    putenv(ServiceAccountCredentials::ENV_VAR . '=' . $keyFile);
+    ApplicationDefaultCredentials::getSubscriber('a scope');
+  }
+
+  public function testLoadsOKIfEnvSpecifiedIsValid()
+  {
+    $keyFile = __DIR__ . '/fixtures' . '/private.json';
+    putenv(ServiceAccountCredentials::ENV_VAR . '=' . $keyFile);
+    $this->assertNotNull(ApplicationDefaultCredentials::getSubscriber('a scope'));
+  }
+
+  public function testLoadsDefaultFileIfPresentAndEnvVarIsNotSet()
+  {
+    putenv('HOME=' . __DIR__ . '/fixtures');
+    $this->assertNotNull(ApplicationDefaultCredentials::getSubscriber('a scope'));
+
+  }
+
+  /**
+   * @expectedException DomainException
+   */
+  public function testFailsIfNotOnGceAndNoDefaultFileFound()
+  {
+    putenv('HOME=' . __DIR__ . '/not_exist_fixtures');
+
+    // simulate not being GCE by return 500
+    $httpHandler = getHandler([
+      buildResponse(500)
+    ]);
+
+    ApplicationDefaultCredentials::getSubscriber('a scope', $httpHandler);
+  }
+
+  public function testSuccedsIfNoDefaultFilesButIsOnGCE()
+  {
+    $wantedTokens = [
+        'access_token' => '1/abdef1234567890',
+        'expires_in' => '57',
+        'token_type' => 'Bearer',
+    ];
+    $jsonTokens = json_encode($wantedTokens);
+
+    // simulate the response from GCE.
+    $httpHandler = getHandler([
+      buildResponse(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
+      buildResponse(200, [], Psr7\stream_for($jsonTokens))
+    ]);
+
+    $this->assertNotNull(ApplicationDefaultCredentials::getSubscriber('a scope', $httpHandler));
   }
 }

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Google\Auth\Tests;
+
+use GuzzleHttp\ClientInterface;
+
+abstract class BaseTest extends \PHPUnit_Framework_TestCase
+{
+  public function onlyGuzzle6()
+  {
+    $version = ClientInterface::VERSION;
+    if ('6' !== $version[0]) {
+      $this->markTestSkipped('Guzzle 6 only');
+    }
+  }
+
+  public function onlyGuzzle5()
+  {
+    $version = ClientInterface::VERSION;
+    if ('5' !== $version[0]) {
+      $this->markTestSkipped('Guzzle 5 only');
+    }
+  }
+}

--- a/tests/CacheTraitTest.php
+++ b/tests/CacheTraitTest.php
@@ -1,0 +1,196 @@
+<?php
+/*
+ * Copyright 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Auth\Tests;
+
+use Google\Auth\CacheTrait;
+
+class CacheTraitTest extends \PHPUnit_Framework_TestCase
+{
+  private $mockFetcher;
+  private $mockCache;
+
+  public function setUp()
+  {
+    $this->mockFetcher =
+      $this
+      ->getMockBuilder('Google\Auth\FetchAuthTokenInterface')
+      ->getMock();
+    $this->mockCache =
+      $this
+      ->getMockBuilder('Google\Auth\CacheInterface')
+      ->getMock();
+  }
+
+  public function testSuccessfullyPullsFromCacheWithoutFetcher()
+  {
+    $expectedValue = '1234';
+    $this->mockCache
+      ->expects($this->once())
+      ->method('get')
+      ->will($this->returnValue($expectedValue));
+
+    $implementation = new CacheTraitImplementation([
+      'cache' => $this->mockCache
+    ]);
+
+    $cachedValue = $implementation->gCachedValue();
+    $this->assertEquals($expectedValue, $cachedValue);
+  }
+
+  public function testSuccessfullyPullsFromCacheWithFetcher()
+  {
+    $expectedValue = '1234';
+    $this->mockCache
+      ->expects($this->once())
+      ->method('get')
+      ->will($this->returnValue($expectedValue));
+    $this->mockFetcher
+      ->expects($this->once())
+      ->method('getCacheKey')
+      ->will($this->returnValue('key'));
+
+    $implementation = new CacheTraitImplementation([
+      'cache' => $this->mockCache,
+      'fetcher' => $this->mockFetcher
+    ]);
+
+    $cachedValue = $implementation->gCachedValue();
+    $this->assertEquals($expectedValue, $cachedValue);
+  }
+
+  public function testFailsPullFromCacheWithNoCache()
+  {
+    $implementation = new CacheTraitImplementation();
+
+    $cachedValue = $implementation->gCachedValue();
+    $this->assertEquals(null, $cachedValue);
+  }
+
+  public function testFailsPullFromCacheWithoutKey()
+  {
+    $this->mockFetcher
+      ->expects($this->once())
+      ->method('getCacheKey')
+      ->will($this->returnValue(null));
+
+    $implementation = new CacheTraitImplementation([
+      'cache' => $this->mockCache,
+      'fetcher' => $this->mockFetcher
+    ]);
+
+    $cachedValue = $implementation->gCachedValue();
+  }
+
+  public function testSuccessfullySetsToCacheWithoutFetcher()
+  {
+    $value = '1234';
+    $this->mockCache
+      ->expects($this->once())
+      ->method('set')
+      ->with('key', $value);
+
+    $implementation = new CacheTraitImplementation([
+      'cache' => $this->mockCache
+    ]);
+
+    $implementation->sCachedValue($value);
+  }
+
+  public function testSuccessfullySetsToCacheWithFetcher()
+  {
+    $value = '1234';
+    $this->mockCache
+      ->expects($this->once())
+      ->method('set')
+      ->with('key', $value);
+    $this->mockFetcher
+      ->expects($this->once())
+      ->method('getCacheKey')
+      ->will($this->returnValue('key'));
+
+    $implementation = new CacheTraitImplementation([
+      'cache' => $this->mockCache,
+      'fetcher' => $this->mockFetcher
+    ]);
+
+    $implementation->sCachedValue($value);
+  }
+
+  public function testFailsSetToCacheWithNoCache()
+  {
+    $this->mockFetcher
+      ->expects($this->never())
+      ->method('getCacheKey');
+
+    $implementation = new CacheTraitImplementation([
+      'fetcher' => $this->mockFetcher
+    ]);
+
+    $implementation->sCachedValue('1234');
+  }
+
+  public function testFailsSetToCacheWithoutKey()
+  {
+    $this->mockFetcher
+      ->expects($this->once())
+      ->method('getCacheKey')
+      ->will($this->returnValue(null));
+
+    $implementation = new CacheTraitImplementation([
+      'cache' => $this->mockCache,
+      'fetcher' => $this->mockFetcher
+    ]);
+
+    $cachedValue = $implementation->sCachedValue('1234');
+  }
+}
+
+class CacheTraitImplementation
+{
+  use CacheTrait;
+
+  private $cache;
+  private $fetcher;
+  private $cacheConfig;
+
+  public function __construct(array $config = [])
+  {
+    $this->cache = isset($config['cache']) ? $config['cache'] : null;
+    $this->fetcher = isset($config['fetcher']) ? $config['fetcher'] : null;
+    $this->cacheConfig = [
+      'prefix' => '',
+      'lifetime' => 1000
+    ];
+  }
+
+  // allows us to keep trait methods private
+  public function gCachedValue()
+  {
+    return $this->getCachedValue();
+  }
+
+  public function sCachedValue($v)
+  {
+    $this->setCachedValue($v);
+  }
+
+  private function getCacheKey()
+  {
+    return 'key';
+  }
+}

--- a/tests/Credentials/AppIndentityCredentialsTest.php
+++ b/tests/Credentials/AppIndentityCredentialsTest.php
@@ -17,11 +17,8 @@
 
 namespace Google\Auth\Tests;
 
-use Google\Auth\AppIdentityCredentials;
-use GuzzleHttp\Client;
-use GuzzleHttp\Message\Response;
-use GuzzleHttp\Stream\Stream;
-use GuzzleHttp\Subscriber\Mock;
+use Google\Auth\Credentials\AppIdentityCredentials;
+use GuzzleHttp\Psr7\Response;
 
 // included from tests\mocks\AppIdentityService.php
 use google\appengine\api\app_identity\AppIdentityService;
@@ -67,7 +64,7 @@ class AppIdentityCredentialsFetchAuthTokenTest extends \PHPUnit_Framework_TestCa
   public function testReturnsExpectedToken()
   {
     // include the mock AppIdentityService class
-    require_once __DIR__ . '/mocks/AppIdentityService.php';
+    require_once __DIR__ . '/../mocks/AppIdentityService.php';
 
     $wantedToken = [
         'access_token' => '1/abdef1234567890',
@@ -86,7 +83,7 @@ class AppIdentityCredentialsFetchAuthTokenTest extends \PHPUnit_Framework_TestCa
   public function testScopeIsAlwaysArray()
   {
     // include the mock AppIdentityService class
-    require_once __DIR__ . '/mocks/AppIdentityService.php';
+    require_once __DIR__ . '/../mocks/AppIdentityService.php';
 
     $scope1 = ['scopeA', 'scopeB'];
     $scope2 = 'scopeA scopeB';

--- a/tests/Credentials/GCECredentialsTest.php
+++ b/tests/Credentials/GCECredentialsTest.php
@@ -79,19 +79,18 @@ class GCECredentialsFetchAuthTokenTest extends \PHPUnit_Framework_TestCase
   }
 
   /**
-   * @ExpectedException \GuzzleHttp\Exception\ParseException
-   * @todo psr7 responses are not throwing a parseexception. do we need this?
+   * @expectedException Exception
+   * @expectedExceptionMessage Invalid JSON response
    */
   public function testShouldFailIfResponseIsNotJson()
   {
-    $this->markTestSkipped();
     $notJson = '{"foo": , this is cannot be passed as json" "bar"}';
     $httpHandler = getHandler([
       buildResponse(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
-      buildResponse(200, [], Psr7\stream_for($notJson)),
+      buildResponse(200, [], $notJson),
     ]);
     $g = new GCECredentials();
-    $this->assertEquals(array(), $g->fetchAuthToken($httpHandler));
+    $g->fetchAuthToken($httpHandler);
   }
 
   public function testShouldReturnTokenInfo()

--- a/tests/Credentials/IAMCredentialsTest.php
+++ b/tests/Credentials/IAMCredentialsTest.php
@@ -17,7 +17,7 @@
 
 namespace Google\Auth\Tests;
 
-use Google\Auth\IAMCredentials;
+use Google\Auth\Credentials\IAMCredentials;
 
 class IAMConstructorTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/HttpHandler/Guzzle5HttpHandlerTest.php
+++ b/tests/HttpHandler/Guzzle5HttpHandlerTest.php
@@ -21,13 +21,11 @@ use Google\Auth\HttpHandler\Guzzle5HttpHandler;
 use GuzzleHttp\Client;
 use GuzzleHttp\Message\Response;
 
-class Guzzle5HttpHandlerTest extends \PHPUnit_Framework_TestCase
+class Guzzle5HttpHandlerTest extends BaseTest
 {
   public function setUp()
   {
-    if (!interface_exists('GuzzleHttp\Event\SubscriberInterface')) {
-      $this->markTestSkipped();
-    }
+    $this->onlyGuzzle5();
 
     $this->mockPsr7Request =
       $this

--- a/tests/HttpHandler/Guzzle5HttpHandlerTest.php
+++ b/tests/HttpHandler/Guzzle5HttpHandlerTest.php
@@ -1,0 +1,62 @@
+<?php
+/*
+ * Copyright 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Auth\Tests;
+
+use Google\Auth\HttpHandler\Guzzle5HttpHandler;
+use GuzzleHttp\Client;
+use GuzzleHttp\Message\Response;
+
+class Guzzle5HttpHandlerTest extends \PHPUnit_Framework_TestCase
+{
+  public function setUp()
+  {
+    if (!interface_exists('GuzzleHttp\Event\SubscriberInterface')) {
+      $this->markTestSkipped();
+    }
+
+    $this->mockPsr7Request =
+      $this
+      ->getMockBuilder('Psr\Http\Message\RequestInterface')
+      ->getMock();
+    $this->mockRequest =
+      $this
+      ->getMockBuilder('GuzzleHttp\Message\RequestInterface')
+      ->getMock();
+    $this->mockClient =
+      $this
+      ->getMockBuilder('GuzzleHttp\Client')
+      ->disableOriginalConstructor()
+      ->getMock();
+  }
+
+  public function testSuccessfullySendsRequest()
+  {
+    $this->mockClient
+      ->expects($this->any())
+      ->method('send')
+      ->will($this->returnValue(new Response(200)));
+    $this->mockClient
+      ->expects($this->any())
+      ->method('createRequest')
+      ->will($this->returnValue($this->mockRequest));
+
+    $handler = new Guzzle5HttpHandler($this->mockClient);
+    $response = $handler($this->mockPsr7Request);
+    $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
+  }
+}

--- a/tests/HttpHandler/Guzzle6HttpHandlerTest.php
+++ b/tests/HttpHandler/Guzzle6HttpHandlerTest.php
@@ -22,13 +22,11 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Response;
 
 
-class Guzzle6HttpHandlerTest extends \PHPUnit_Framework_TestCase
+class Guzzle6HttpHandlerTest extends BaseTest
 {
   public function setUp()
   {
-    if (!class_exists('GuzzleHttp\HandlerStack')) {
-      $this->markTestSkipped();
-    }
+    $this->onlyGuzzle6();
 
     $this->mockRequest =
       $this

--- a/tests/HttpHandler/Guzzle6HttpHandlerTest.php
+++ b/tests/HttpHandler/Guzzle6HttpHandlerTest.php
@@ -1,0 +1,54 @@
+<?php
+/*
+ * Copyright 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Auth\Tests;
+
+use Google\Auth\HttpHandler\Guzzle6HttpHandler;
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Response;
+
+
+class Guzzle6HttpHandlerTest extends \PHPUnit_Framework_TestCase
+{
+  public function setUp()
+  {
+    if (!class_exists('GuzzleHttp\HandlerStack')) {
+      $this->markTestSkipped();
+    }
+
+    $this->mockRequest =
+      $this
+      ->getMockBuilder('Psr\Http\Message\RequestInterface')
+      ->getMock();
+    $this->mockClient =
+      $this
+      ->getMockBuilder('GuzzleHttp\Client')
+      ->getMock();
+  }
+
+  public function testSuccessfullySendsRequest()
+  {
+    $this->mockClient
+      ->expects($this->any())
+      ->method('send')
+      ->will($this->returnValue(new Response(200)));
+
+    $handler = new Guzzle6HttpHandler($this->mockClient);
+    $response = $handler($this->mockRequest);
+    $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
+  }
+}

--- a/tests/HttpHandler/HttpHandlerFactoryTest.php
+++ b/tests/HttpHandler/HttpHandlerFactoryTest.php
@@ -19,13 +19,11 @@ namespace Google\Auth\Tests;
 
 use Google\Auth\HttpHandler\HttpHandlerFactory;
 
-class HttpHandlerFactoryTest extends \PHPUnit_Framework_TestCase
+class HttpHandlerFactoryTest extends BaseTest
 {
   public function testBuildsGuzzle5Handler()
   {
-    if (!interface_exists('GuzzleHttp\Event\SubscriberInterface')) {
-      $this->markTestSkipped();
-    }
+    $this->onlyGuzzle5();
 
     $handler = HttpHandlerFactory::build();
     $this->assertInstanceOf('Google\Auth\HttpHandler\Guzzle5HttpHandler', $handler);
@@ -33,9 +31,7 @@ class HttpHandlerFactoryTest extends \PHPUnit_Framework_TestCase
 
   public function testBuildsGuzzle6Handler()
   {
-    if (!class_exists('GuzzleHttp\HandlerStack')) {
-      $this->markTestSkipped();
-    }
+    $this->onlyGuzzle6();
 
     $handler = HttpHandlerFactory::build();
     $this->assertInstanceOf('Google\Auth\HttpHandler\Guzzle6HttpHandler', $handler);

--- a/tests/HttpHandler/HttpHandlerFactoryTest.php
+++ b/tests/HttpHandler/HttpHandlerFactoryTest.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ * Copyright 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Auth\Tests;
+
+use Google\Auth\HttpHandler\HttpHandlerFactory;
+
+class HttpHandlerFactoryTest extends \PHPUnit_Framework_TestCase
+{
+  public function testBuildsGuzzle5Handler()
+  {
+    if (!interface_exists('GuzzleHttp\Event\SubscriberInterface')) {
+      $this->markTestSkipped();
+    }
+
+    $handler = HttpHandlerFactory::build();
+    $this->assertInstanceOf('Google\Auth\HttpHandler\Guzzle5HttpHandler', $handler);
+  }
+
+  public function testBuildsGuzzle6Handler()
+  {
+    if (!class_exists('GuzzleHttp\HandlerStack')) {
+      $this->markTestSkipped();
+    }
+
+    $handler = HttpHandlerFactory::build();
+    $this->assertInstanceOf('Google\Auth\HttpHandler\Guzzle6HttpHandler', $handler);
+  }
+}

--- a/tests/Middleware/AuthTokenMiddlewareTest.php
+++ b/tests/Middleware/AuthTokenMiddlewareTest.php
@@ -22,7 +22,7 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 
-class AuthTokenMiddlewareTest extends \PHPUnit_Framework_TestCase
+class AuthTokenMiddlewareTest extends BaseTest
 {
   private $mockFetcher;
   private $mockCache;
@@ -30,9 +30,7 @@ class AuthTokenMiddlewareTest extends \PHPUnit_Framework_TestCase
 
   protected function setUp()
   {
-    if (!class_exists('GuzzleHttp\HandlerStack')) {
-      $this->markTestSkipped();
-    }
+    $this->onlyGuzzle6();
 
     $this->mockFetcher =
       $this

--- a/tests/Middleware/ScopedAccessTokenMiddlewareTest.php
+++ b/tests/Middleware/ScopedAccessTokenMiddlewareTest.php
@@ -22,7 +22,7 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 
-class ScopedAccessTokenMiddlewareTest extends \PHPUnit_Framework_TestCase
+class ScopedAccessTokenMiddlewareTest extends BaseTest
 {
   const TEST_SCOPE = 'https://www.googleapis.com/auth/cloud-taskqueue';
 
@@ -31,9 +31,7 @@ class ScopedAccessTokenMiddlewareTest extends \PHPUnit_Framework_TestCase
 
   protected function setUp()
   {
-    if (!class_exists('GuzzleHttp\HandlerStack')) {
-      $this->markTestSkipped();
-    }
+    $this->onlyGuzzle6();
 
     $this->mockCache =
       $this

--- a/tests/Middleware/ScopedAccessTokenMiddlewareTest.php
+++ b/tests/Middleware/ScopedAccessTokenMiddlewareTest.php
@@ -1,0 +1,222 @@
+<?php
+/*
+ * Copyright 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Auth\Tests;
+
+use Google\Auth\Middleware\ScopedAccessTokenMiddleware;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+
+class ScopedAccessTokenMiddlewareTest extends \PHPUnit_Framework_TestCase
+{
+  const TEST_SCOPE = 'https://www.googleapis.com/auth/cloud-taskqueue';
+
+  private $mockCache;
+  private $mockRequest;
+
+  protected function setUp()
+  {
+    if (!class_exists('GuzzleHttp\HandlerStack')) {
+      $this->markTestSkipped();
+    }
+
+    $this->mockCache =
+      $this
+      ->getMockBuilder('Google\Auth\CacheInterface')
+      ->getMock();
+    $this->mockRequest =
+      $this
+      ->getMockBuilder('GuzzleHttp\Psr7\Request')
+      ->disableOriginalConstructor()
+      ->getMock();
+  }
+
+  /**
+   * @expectedException InvalidArgumentException
+   */
+  public function testRequiresScopeAsAStringOrArray()
+  {
+    $fakeAuthFunc = function ($unused_scopes) {
+       return '1/abcdef1234567890';
+    };
+    new ScopedAccessTokenMiddleware($fakeAuthFunc, new \stdClass());
+  }
+
+  public function testAddsTheTokenAsAnAuthorizationHeader()
+  {
+    $token = '1/abcdef1234567890';
+    $fakeAuthFunc = function ($unused_scopes) use ($token) {
+       return $token;
+    };
+    $this->mockRequest
+      ->expects($this->once())
+      ->method('withHeader')
+      ->with('Authorization', 'Bearer ' . $token)
+      ->will($this->returnValue($this->mockRequest));
+
+    // Run the test
+    $middleware = new ScopedAccessTokenMiddleware($fakeAuthFunc, self::TEST_SCOPE);
+    $mock = new MockHandler([new Response(200)]);
+    $callable = $middleware($mock);
+    $callable($this->mockRequest, ['auth' => 'scoped']);
+  }
+
+  public function testUsesCachedAuthToken()
+  {
+    $cachedValue = '2/abcdef1234567890';
+    $fakeAuthFunc = function ($unused_scopes) {
+       return '';
+    };
+    $this->mockCache
+        ->expects($this->once())
+        ->method('get')
+        ->will($this->returnValue($cachedValue));
+    $this->mockRequest
+      ->expects($this->once())
+      ->method('withHeader')
+      ->with('Authorization', 'Bearer ' . $cachedValue)
+      ->will($this->returnValue($this->mockRequest));
+
+    // Run the test
+    $middleware = new ScopedAccessTokenMiddleware(
+      $fakeAuthFunc,
+      self::TEST_SCOPE,
+      [],
+      $this->mockCache
+    );
+    $mock = new MockHandler([new Response(200)]);
+    $callable = $middleware($mock);
+    $callable($this->mockRequest, ['auth' => 'scoped']);
+  }
+
+  public function testGetsCachedAuthTokenUsingCacheOptions()
+  {
+    $prefix = 'test_prefix:';
+    $lifetime = '70707';
+    $cachedValue = '2/abcdef1234567890';
+    $fakeAuthFunc = function ($unused_scopes) {
+       return '';
+    };
+    $this->mockCache
+        ->expects($this->once())
+        ->method('get')
+        ->with($this->equalTo($prefix . self::TEST_SCOPE),
+               $this->equalTo($lifetime))
+        ->will($this->returnValue($cachedValue));
+    $this->mockRequest
+      ->expects($this->once())
+      ->method('withHeader')
+      ->with('Authorization', 'Bearer ' . $cachedValue)
+      ->will($this->returnValue($this->mockRequest));
+
+    // Run the test
+    $middleware = new ScopedAccessTokenMiddleware(
+      $fakeAuthFunc,
+      self::TEST_SCOPE,
+      ['prefix' => $prefix, 'lifetime' => $lifetime],
+      $this->mockCache
+    );
+    $mock = new MockHandler([new Response(200)]);
+    $callable = $middleware($mock);
+    $callable($this->mockRequest, ['auth' => 'scoped']);
+  }
+
+  public function testShouldSaveValueInCache()
+  {
+    $token = '2/abcdef1234567890';
+    $fakeAuthFunc = function ($unused_scopes) use ($token) {
+       return $token;
+    };
+    $this->mockCache
+        ->expects($this->once())
+        ->method('get')
+        ->will($this->returnValue(false));
+    $this->mockCache
+        ->expects($this->once())
+        ->method('set')
+        ->with($this->equalTo(self::TEST_SCOPE), $this->equalTo($token))
+        ->will($this->returnValue(false));
+    $this->mockRequest
+      ->expects($this->once())
+      ->method('withHeader')
+      ->with('Authorization', 'Bearer ' . $token)
+      ->will($this->returnValue($this->mockRequest));
+
+    // Run the test
+    $middleware = new ScopedAccessTokenMiddleware(
+      $fakeAuthFunc,
+      self::TEST_SCOPE,
+      [],
+      $this->mockCache
+    );
+    $mock = new MockHandler([new Response(200)]);
+    $callable = $middleware($mock);
+    $callable($this->mockRequest, ['auth' => 'scoped']);
+  }
+
+  public function testShouldSaveValueInCacheWithSpecifiedPrefix()
+  {
+    $token = '2/abcdef1234567890';
+    $prefix = 'test_prefix:';
+    $fakeAuthFunc = function ($unused_scopes) use ($token) {
+       return $token;
+    };
+    $this->mockCache
+        ->expects($this->once())
+        ->method('get')
+        ->will($this->returnValue(false));
+    $this->mockCache
+        ->expects($this->once())
+        ->method('set')
+        ->with($this->equalTo($prefix . self::TEST_SCOPE),
+               $this->equalTo($token))
+        ->will($this->returnValue(false));
+    $this->mockRequest
+      ->expects($this->once())
+      ->method('withHeader')
+      ->with('Authorization', 'Bearer ' . $token)
+      ->will($this->returnValue($this->mockRequest));
+
+    // Run the test
+    $middleware = new ScopedAccessTokenMiddleware(
+      $fakeAuthFunc,
+      self::TEST_SCOPE,
+      ['prefix' => $prefix],
+      $this->mockCache
+    );
+    $mock = new MockHandler([new Response(200)]);
+    $callable = $middleware($mock);
+    $callable($this->mockRequest, ['auth' => 'scoped']);
+  }
+
+  public function testOnlyTouchesWhenAuthConfigScoped()
+  {
+    $fakeAuthFunc = function ($unused_scopes) {
+       return '1/abcdef1234567890';
+    };
+    $this->mockRequest
+      ->expects($this->never())
+      ->method('withHeader');
+
+    // Run the test
+    $middleware = new ScopedAccessTokenMiddleware($fakeAuthFunc, self::TEST_SCOPE);
+    $mock = new MockHandler([new Response(200)]);
+    $callable = $middleware($mock);
+    $callable($this->mockRequest, ['auth' => 'not_scoped']);
+  }
+}

--- a/tests/Middleware/SimpleMiddlewareTest.php
+++ b/tests/Middleware/SimpleMiddlewareTest.php
@@ -23,7 +23,7 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Uri;
 
-class SimpleMiddlewareTest extends \PHPUnit_Framework_TestCase
+class SimpleMiddlewareTest extends BaseTest
 {
   private $mockRequest;
 
@@ -32,9 +32,7 @@ class SimpleMiddlewareTest extends \PHPUnit_Framework_TestCase
    */
   protected function setUp()
   {
-    if (!class_exists('GuzzleHttp\HandlerStack')) {
-      $this->markTestSkipped();
-    }
+    $this->onlyGuzzle6();
 
     $this->mockRequest =
       $this

--- a/tests/Middleware/SimpleMiddlewareTest.php
+++ b/tests/Middleware/SimpleMiddlewareTest.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Auth\Tests;
+
+use Google\Auth\Middleware\SimpleMiddleware;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Uri;
+
+class SimpleMiddlewareTest extends \PHPUnit_Framework_TestCase
+{
+  private $mockRequest;
+
+  /**
+   * @todo finish
+   */
+  protected function setUp()
+  {
+    if (!class_exists('GuzzleHttp\HandlerStack')) {
+      $this->markTestSkipped();
+    }
+
+    $this->mockRequest =
+      $this
+      ->getMockBuilder('GuzzleHttp\Psr7\Request')
+      ->disableOriginalConstructor()
+      ->getMock();
+  }
+
+  public function testTest()
+  {
+
+  }
+}

--- a/tests/OAuth2Test.php
+++ b/tests/OAuth2Test.php
@@ -217,8 +217,7 @@ class OAuth2GrantTypeTest extends \PHPUnit_Framework_TestCase
   {
     $o = new OAuth2($this->minimal);
     $o->setGrantType('http://a/grant/url');
-    $this->assertInstanceOf('GuzzleHttp\Psr7\Uri', $o->getGrantType());
-    $this->assertEquals('http://a/grant/url', strval($o->getGrantType()));
+    $this->assertEquals('http://a/grant/url', $o->getGrantType());
   }
 }
 
@@ -345,14 +344,12 @@ class OAuth2GeneralTest extends \PHPUnit_Framework_TestCase
   }
 
 
-  //@todo was having trouble with urn uri's in the psr7 uri implementation. dig in deeper
   public function testAllowsUrnRedirectUri()
   {
-    $this->markTestSkipped();
     $urn = 'urn:ietf:wg:oauth:2.0:oob';
     $o = new OAuth2($this->minimal);
     $o->setRedirectUri($urn);
-    $this->assertEquals($urn, (string) $o->getRedirectUri());
+    $this->assertEquals($urn, $o->getRedirectUri());
   }
 }
 
@@ -590,10 +587,8 @@ class OAuth2GenerateAccessTokenRequestTest extends \PHPUnit_Framework_TestCase
     $this->assertTrue(array_key_exists('assertion', $fields));
   }
 
-  //@todo was having trouble with urn uri's in the psr7 uri implementation. dig in deeper
   public function testGeneratesExtendedRequests()
   {
-    $this->markTestSkipped();
     $testConfig = $this->tokenRequestMinimal;
     $o = new OAuth2($testConfig);
     $o->setGrantType('urn:my_test_grant_type');
@@ -648,12 +643,11 @@ class OAuth2FetchAuthTokenTest extends \PHPUnit_Framework_TestCase
   }
 
   /**
-   * @ExpectedException GuzzleHttp\Exception\ParseException
-   * @todo psr7 responses do not appear to throw exceptions on invalid json. follow up
+   * @expectedException Exception
+   * @expectedExceptionMessage Invalid JSON response
    */
   public function testFailsOnNoContentTypeIfResponseIsNotJSON()
   {
-    $this->markTestSkipped();
     $testConfig = $this->fetchAuthTokenMinimal;
     $notJson = '{"foo": , this is cannot be passed as json" "bar"}';
     $httpHandler = getHandler([

--- a/tests/Subscriber/AuthTokenSubscriberTest.php
+++ b/tests/Subscriber/AuthTokenSubscriberTest.php
@@ -23,16 +23,14 @@ use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Event\BeforeEvent;
 use GuzzleHttp\Transaction;
 
-class AuthTokenSubscriberTest extends \PHPUnit_Framework_TestCase
+class AuthTokenSubscriberTest extends BaseTest
 {
   private $mockFetcher;
   private $mockCache;
 
   protected function setUp()
   {
-    if (!interface_exists('GuzzleHttp\Event\SubscriberInterface')) {
-      $this->markTestSkipped();
-    }
+    $this->onlyGuzzle5();
 
     $this->mockFetcher =
         $this

--- a/tests/Subscriber/AuthTokenSubscriberTest.php
+++ b/tests/Subscriber/AuthTokenSubscriberTest.php
@@ -1,0 +1,203 @@
+<?php
+/*
+ * Copyright 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Auth\Tests;
+
+use Google\Auth\Subscriber\AuthTokenSubscriber;
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Event\BeforeEvent;
+use GuzzleHttp\Transaction;
+
+class AuthTokenSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+  private $mockFetcher;
+  private $mockCache;
+
+  protected function setUp()
+  {
+    if (!interface_exists('GuzzleHttp\Event\SubscriberInterface')) {
+      $this->markTestSkipped();
+    }
+
+    $this->mockFetcher =
+        $this
+        ->getMockBuilder('Google\Auth\FetchAuthTokenInterface')
+        ->getMock();
+    $this->mockCache =
+        $this
+        ->getMockBuilder('Google\Auth\CacheInterface')
+        ->getMock();
+  }
+
+  public function testSubscribesToEvents()
+  {
+    $a = new AuthTokenSubscriber($this->mockFetcher, array());
+    $this->assertArrayHasKey('before', $a->getEvents());
+  }
+
+
+  public function testOnlyTouchesWhenAuthConfigScoped()
+  {
+    $s = new AuthTokenSubscriber($this->mockFetcher, array());
+    $client = new Client();
+    $request = $client->createRequest('GET', 'http://testing.org',
+                                      ['auth' => 'not_google_auth']);
+    $before = new BeforeEvent(new Transaction($client, $request));
+    $s->onBefore($before);
+    $this->assertSame($request->getHeader('Authorization'), '');
+  }
+
+  public function testAddsTheTokenAsAnAuthorizationHeader()
+  {
+    $authResult = ['access_token' => '1/abcdef1234567890'];
+    $this->mockFetcher
+        ->expects($this->once())
+        ->method('fetchAuthToken')
+        ->will($this->returnValue($authResult));
+
+    // Run the test.
+    $a = new AuthTokenSubscriber($this->mockFetcher, array());
+    $client = new Client();
+    $request = $client->createRequest('GET', 'http://testing.org',
+                                      ['auth' => 'google_auth']);
+    $before = new BeforeEvent(new Transaction($client, $request));
+    $a->onBefore($before);
+    $this->assertSame($request->getHeader('Authorization'),
+                      'Bearer 1/abcdef1234567890');
+  }
+
+  public function testDoesNotAddAnAuthorizationHeaderOnNoAccessToken()
+  {
+    $authResult = ['not_access_token' => '1/abcdef1234567890'];
+    $this->mockFetcher
+        ->expects($this->once())
+        ->method('fetchAuthToken')
+        ->will($this->returnValue($authResult));
+
+    // Run the test.
+    $a = new AuthTokenSubscriber($this->mockFetcher, array());
+    $client = new Client();
+    $request = $client->createRequest('GET', 'http://testing.org',
+                                      ['auth' => 'google_auth']);
+    $before = new BeforeEvent(new Transaction($client, $request));
+    $a->onBefore($before);
+    $this->assertSame($request->getHeader('Authorization'), '');
+  }
+
+  public function testUsesCachedAuthToken()
+  {
+    $cacheKey = 'myKey';
+    $cachedValue = '2/abcdef1234567890';
+    $this->mockCache
+        ->expects($this->once())
+        ->method('get')
+        ->with($this->equalTo($cacheKey),
+               $this->equalTo(AuthTokenSubscriber::DEFAULT_CACHE_LIFETIME))
+        ->will($this->returnValue($cachedValue));
+    $this->mockFetcher
+        ->expects($this->never())
+        ->method('fetchAuthToken');
+    $this->mockFetcher
+        ->expects($this->any())
+        ->method('getCacheKey')
+        ->will($this->returnValue($cacheKey));
+
+    // Run the test.
+    $a = new AuthTokenSubscriber($this->mockFetcher, array(), $this->mockCache);
+    $client = new Client();
+    $request = $client->createRequest('GET', 'http://testing.org',
+                                      ['auth' => 'google_auth']);
+    $before = new BeforeEvent(new Transaction($client, $request));
+    $a->onBefore($before);
+    $this->assertSame($request->getHeader('Authorization'),
+                      'Bearer 2/abcdef1234567890');
+  }
+
+  public function testGetsCachedAuthTokenUsingCacheOptions()
+  {
+    $prefix = 'test_prefix:';
+    $lifetime = '70707';
+    $cacheKey = 'myKey';
+    $cachedValue = '2/abcdef1234567890';
+    $this->mockCache
+        ->expects($this->once())
+        ->method('get')
+        ->with($this->equalTo($prefix . $cacheKey),
+               $this->equalTo($lifetime))
+        ->will($this->returnValue($cachedValue));
+    $this->mockFetcher
+        ->expects($this->never())
+        ->method('fetchAuthToken');
+    $this->mockFetcher
+        ->expects($this->any())
+        ->method('getCacheKey')
+        ->will($this->returnValue($cacheKey));
+
+    // Run the test
+    $a = new AuthTokenSubscriber($this->mockFetcher,
+                              array('prefix' => $prefix,
+                                    'lifetime' => $lifetime),
+                              $this->mockCache);
+    $client = new Client();
+    $request = $client->createRequest('GET', 'http://testing.org',
+                                      ['auth' => 'google_auth']);
+    $before = new BeforeEvent(new Transaction($client, $request));
+    $a->onBefore($before);
+    $this->assertSame($request->getHeader('Authorization'),
+                      'Bearer 2/abcdef1234567890');
+  }
+
+  public function testShouldSaveValueInCacheWithSpecifiedPrefix()
+  {
+    $token = '1/abcdef1234567890';
+    $authResult = ['access_token' => $token];
+    $cacheKey = 'myKey';
+    $prefix = 'test_prefix:';
+    $this->mockCache
+        ->expects($this->any())
+        ->method('get')
+        ->will($this->returnValue(null));
+    $this->mockCache
+        ->expects($this->once())
+        ->method('set')
+        ->with($this->equalTo($prefix . $cacheKey),
+               $this->equalTo($token))
+        ->will($this->returnValue(false));
+    $this->mockFetcher
+        ->expects($this->any())
+        ->method('getCacheKey')
+        ->will($this->returnValue($cacheKey));
+    $this->mockFetcher
+        ->expects($this->once())
+        ->method('fetchAuthToken')
+        ->will($this->returnValue($authResult));
+
+    // Run the test
+    $a = new AuthTokenSubscriber($this->mockFetcher,
+                              array('prefix' => $prefix),
+                              $this->mockCache);
+
+    $client = new Client();
+    $request = $client->createRequest('GET', 'http://testing.org',
+                                      ['auth' => 'google_auth']);
+    $before = new BeforeEvent(new Transaction($client, $request));
+    $a->onBefore($before);
+    $this->assertSame($request->getHeader('Authorization'),
+                      'Bearer 1/abcdef1234567890');
+  }
+}

--- a/tests/Subscriber/ScopedAccessTokenSubscriberTest.php
+++ b/tests/Subscriber/ScopedAccessTokenSubscriberTest.php
@@ -22,15 +22,13 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Event\BeforeEvent;
 use GuzzleHttp\Transaction;
 
-class ScopedAccessTokenSubscriberTest extends \PHPUnit_Framework_TestCase
+class ScopedAccessTokenSubscriberTest extends BaseTest
 {
   const TEST_SCOPE = 'https://www.googleapis.com/auth/cloud-taskqueue';
 
   protected function setUp()
   {
-    if (!interface_exists('GuzzleHttp\Event\SubscriberInterface')) {
-      $this->markTestSkipped();
-    }
+    $this->onlyGuzzle5();
   }
 
   /**

--- a/tests/Subscriber/SimpleSubscriberTest.php
+++ b/tests/Subscriber/SimpleSubscriberTest.php
@@ -22,13 +22,11 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Event\BeforeEvent;
 use GuzzleHttp\Transaction;
 
-class SimpleSubscriberTest extends \PHPUnit_Framework_TestCase
+class SimpleSubscriberTest extends BaseTest
 {
   protected function setUp()
   {
-    if (!interface_exists('GuzzleHttp\Event\SubscriberInterface')) {
-      $this->markTestSkipped();
-    }
+    $this->onlyGuzzle5();
   }
 
   /**

--- a/tests/Subscriber/SimpleSubscriberTest.php
+++ b/tests/Subscriber/SimpleSubscriberTest.php
@@ -17,31 +17,37 @@
 
 namespace Google\Auth\Tests;
 
-use Google\Auth\Simple;
+use Google\Auth\Subscriber\SimpleSubscriber;
 use GuzzleHttp\Client;
 use GuzzleHttp\Event\BeforeEvent;
 use GuzzleHttp\Transaction;
 
-class SimpleTest extends \PHPUnit_Framework_TestCase
+class SimpleSubscriberTest extends \PHPUnit_Framework_TestCase
 {
+  protected function setUp()
+  {
+    if (!interface_exists('GuzzleHttp\Event\SubscriberInterface')) {
+      $this->markTestSkipped();
+    }
+  }
 
   /**
    * @expectedException InvalidArgumentException
    */
   public function testRequiresADeveloperKey()
   {
-    new Simple(['not_key' => 'a test key']);
+    new SimpleSubscriber(['not_key' => 'a test key']);
   }
 
   public function testSubscribesToEvents()
   {
-    $events = (new Simple(['key' => 'a test key']))->getEvents();
+    $events = (new SimpleSubscriber(['key' => 'a test key']))->getEvents();
     $this->assertArrayHasKey('before', $events);
   }
 
   public function testAddsTheKeyToTheQuery()
   {
-    $s = new Simple(['key' => 'test_key']);
+    $s = new SimpleSubscriber(['key' => 'test_key']);
     $client = new Client();
     $request = $client->createRequest('GET', 'http://testing.org',
                                       ['auth' => 'simple']);
@@ -54,7 +60,7 @@ class SimpleTest extends \PHPUnit_Framework_TestCase
 
   public function testOnlyTouchesWhenAuthConfigIsSimple()
   {
-    $s = new Simple(['key' => 'test_key']);
+    $s = new SimpleSubscriber(['key' => 'test_key']);
     $client = new Client();
     $request = $client->createRequest('GET', 'http://testing.org',
                                       ['auth' => 'notsimple']);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -19,6 +19,9 @@ error_reporting(E_ALL | E_STRICT);
 require dirname(__DIR__) . '/vendor/autoload.php';
 date_default_timezone_set('UTC');
 
+// autoload base test
+require_once __DIR__ . '/BaseTest.php';
+
 function buildResponse($code, array $headers = [], $body = null)
 {
   if (class_exists('GuzzleHttp\HandlerStack')) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2014 Google Inc.
+ * Copyright 2015 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,3 +18,33 @@
 error_reporting(E_ALL | E_STRICT);
 require dirname(__DIR__) . '/vendor/autoload.php';
 date_default_timezone_set('UTC');
+
+function buildResponse($code, array $headers = [], $body = null)
+{
+  if (class_exists('GuzzleHttp\HandlerStack')) {
+    return new \GuzzleHttp\Psr7\Response($code, $headers, $body);
+  }
+
+  return new \GuzzleHttp\Message\Response(
+    $code,
+    $headers,
+    \GuzzleHttp\Stream\Stream::factory((string) $body)
+  );
+}
+
+function getHandler(array $mockResponses = [])
+{
+  if (class_exists('GuzzleHttp\HandlerStack')) {
+    $mock = new \GuzzleHttp\Handler\MockHandler($mockResponses);
+
+    $handler = \GuzzleHttp\HandlerStack::create($mock);
+    $client = new \GuzzleHttp\Client(['handler' => $handler]);
+    return new \Google\Auth\HttpHandler\Guzzle6HttpHandler($client);
+  }
+
+  $client = new \GuzzleHttp\Client();
+  $client->getEmitter()->attach(
+    new \GuzzleHttp\Subscriber\Mock($mockResponses)
+  );
+  return new \Google\Auth\HttpHandler\Guzzle5HttpHandler($client);
+}


### PR DESCRIPTION
Notable changes:

- Organized classes under new namespaces (ex. ```Google\Auth\GCECredentials``` is now found under the ```Google\Auth\Credentials\GCECredentials``` namespace
- Renamed 'getFetcher' to 'getSubscriber'
```
use Google\Auth\ApplicationDefaultCredentials;

ApplicationDefaultCredentials::getFetcher() // no-mo
ApplicationDefaultCredentials::getSubscriber() // +1
```
- Added guzzle 6 middleware implementations 
```
use Google\Auth\ApplicationDefaultCredentials;
use GuzzleHttp\Client;
use GuzzleHttp\HandlerStack;

$middleware = ApplicationDefaultCredentials::getMiddleware(
    'https://www.googleapis.com/auth/taskqueue'
);
$stack = HandlerStack::create();
$stack->push($middleware);

$client = new Client([
    'handler' => $stack,
    'base_uri' => 'https://www.googleapis.com/taskqueue/v1beta2/projects/',
    'auth' => 'google_auth' // authorize all requests
]);

$res = $client->get('myproject/taskqueues/myqueue');
```
- Support for guzzle 5/6 as the default transport layer - however you can now also define a custom layer as follows:
```
use Google\Auth\Credentials\GCECredentials;
use GuzzleHttp\Psr7\Response;
use Psr\Http\Message\RequestInterface;

$isOnGCE = GCECredentials::onGce(function (RequestInterface $request, $options = []) {
    // define your own http implementation which returns a PSR7 response
    return Response(200);
});
```

The code is functional but please keep in mind there are still a few ```@todos``` which need to be addressed.