### PR TITLE
Allow use of Guzzle 5.3 too

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "require": {
     "firebase/php-jwt": "~2.0|~3.0",
-    "guzzlehttp/guzzle": "5.2.*",
+    "guzzlehttp/guzzle": "~5.2",
     "php": ">=5.4"
   },
   "require-dev": {


### PR DESCRIPTION
Nothing in the current code seems to prevent the use of Guzzle 5.3.

Of course, this PR is superseded by https://github.com/google/google-auth-library-php/pull/85.