### PR TITLE
Use PHP_OS constants instead of php_uname().

### DIFF
--- a/src/CredentialsLoader.php
+++ b/src/CredentialsLoader.php
@@ -45,7 +45,7 @@ abstract class CredentialsLoader implements FetchAuthTokenInterface
 
   private static function isOnWindows()
   {
-    return strtoupper(substr(php_uname('s'), 0, 3)) === 'WIN';
+    return strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
   }
 
   /**


### PR DESCRIPTION
According to:
http://php.net/manual/en/function.php-uname.php
It is recommended using PHP_OS if possible.