### PR TITLE
Removed dev-master from README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,8 @@ curl -sS https://getcomposer.org/installer | php
 Next, run the Composer command to install the latest stable version:
 
 ```bash
-composer.phar require google/auth:dev-master
+composer.phar require google/auth
 ```
-
-> As this project is in alpha, there is currently no "stable" composer version,
-> so specifying `dev-master` is required.
 
 ## Application Default Credentials
 


### PR DESCRIPTION
Since we have releases, can we remove dev-master from the README?