### PR TITLE
Fixing some service account flow JWT issues.

### DIFF
--- a/src/Credentials/ServiceAccountCredentials.php
+++ b/src/Credentials/ServiceAccountCredentials.php
@@ -37,12 +37,10 @@ use GuzzleHttp\Psr7;
  *   use Google\Auth\Middleware\AuthTokenMiddleware;
  *   use GuzzleHttp\Client;
  *   use GuzzleHttp\HandlerStack;
- *   use GuzzleHttp\Psr7;
  *
- *   $stream = Psr7\stream_for(file_get_contents(<my_key_file>));
  *   $sa = new ServiceAccountCredentials(
  *       'https://www.googleapis.com/auth/taskqueue',
- *       $stream
+ *       '/path/to/your/json/key_file.json'
  *   );
  *   $middleware = new AuthTokenMiddleware($sa);
  *   $stack = HandlerStack::create();
@@ -64,10 +62,8 @@ class ServiceAccountCredentials extends CredentialsLoader
    * @param string|array $scope the scope of the access request, expressed
    *   either as an Array or as a space-delimited String.
    *
-   * @param array $jsonKey JSON credentials.
-   *
-   * @param string $jsonKeyPath the path to a file containing JSON credentials.  If
-   *   jsonKeyStream is set, it is ignored.
+   * @param string|array $jsonKey JSON credential file path or JSON credentials
+   *   as an associative array
    *
    * @param string $sub an email address account to impersonate, in situations when
    *   the service account has been delegated domain wide access.
@@ -75,12 +71,16 @@ class ServiceAccountCredentials extends CredentialsLoader
   public function __construct(
     $scope,
     $jsonKey,
-    $jsonKeyPath = null,
     $sub = null
   ) {
-    if (is_null($jsonKey)) {
-      $jsonKeyStream = Psr7\stream_for(file_get_contents($jsonKeyPath));
-      $jsonKey = json_decode($jsonKeyStream->getContents(), true);
+    if (is_string($jsonKey)) {
+      if (!file_exists($jsonKey)) {
+        throw new \InvalidArgumentException('file does not exist');
+      }
+      $jsonKeyStream = Psr7\stream_for(file_get_contents($jsonKey));
+      if (!$jsonKey = json_decode($jsonKeyStream, true)) {
+        throw new \LogicException('invalid json for auth config');
+      }
     }
     if (!array_key_exists('client_email', $jsonKey)) {
       throw new \InvalidArgumentException(

--- a/src/CredentialsLoader.php
+++ b/src/CredentialsLoader.php
@@ -28,7 +28,7 @@ use Psr\Http\Message\StreamInterface;
  */
 abstract class CredentialsLoader implements FetchAuthTokenInterface
 {
-  const TOKEN_CREDENTIAL_URI = 'https://www.googleapis.com/oauth2/v3/token';
+  const TOKEN_CREDENTIAL_URI = 'https://www.googleapis.com/oauth2/v4/token';
   const ENV_VAR = 'GOOGLE_APPLICATION_CREDENTIALS';
   const WELL_KNOWN_PATH = 'gcloud/application_default_credentials.json';
   const NON_WINDOWS_WELL_KNOWN_PATH_BASE = '.config';

--- a/tests/Credentials/ServiceAccountCredentialsTest.php
+++ b/tests/Credentials/ServiceAccountCredentialsTest.php
@@ -63,7 +63,6 @@ class SACGetCacheKeyTest extends \PHPUnit_Framework_TestCase
     $sa = new ServiceAccountCredentials(
         $scope,
         $testJson,
-        null,
         $sub);
     $o = new OAuth2(['scope' => $scope]);
     $this->assertSame(
@@ -135,19 +134,19 @@ class SACConstructorTest extends \PHPUnit_Framework_TestCase
   }
 
   /**
-   * @expectedException PHPUnit_Framework_Error_Warning
+   * @expectedException InvalidArgumentException
    */
   public function testFailsToInitalizeFromANonExistentFile()
   {
     $keyFile = __DIR__ . '/../fixtures' . '/does-not-exist-private.json';
-    new ServiceAccountCredentials('scope/1', null, $keyFile);
+    new ServiceAccountCredentials('scope/1', $keyFile);
   }
 
   public function testInitalizeFromAFile()
   {
     $keyFile = __DIR__ . '/../fixtures' . '/private.json';
     $this->assertNotNull(
-        new ServiceAccountCredentials('scope/1', null, $keyFile)
+        new ServiceAccountCredentials('scope/1', $keyFile)
     );
   }
 }


### PR DESCRIPTION
 - Fixed default expiry time to be in seconds, also renamed skew variable for clarity.
 - Fixed documentation on service accounts creds class.
 - Removed obsolete 'prn' JWT claim and all references to it.
 - Updated `CredentialsLoader::TOKEN_CREDENTIAL_URI` to v4.

Fixes #94.