### PR TITLE
update oauth2 token URI to v4

### DIFF
--- a/src/CredentialsLoader.php
+++ b/src/CredentialsLoader.php
@@ -28,7 +28,7 @@ use Psr\Http\Message\StreamInterface;
  */
 abstract class CredentialsLoader implements FetchAuthTokenInterface
 {
-  const TOKEN_CREDENTIAL_URI = 'https://www.googleapis.com/oauth2/v3/token';
+  const TOKEN_CREDENTIAL_URI = 'https://www.googleapis.com/oauth2/v4/token';
   const ENV_VAR = 'GOOGLE_APPLICATION_CREDENTIALS';
   const WELL_KNOWN_PATH = 'gcloud/application_default_credentials.json';
   const NON_WINDOWS_WELL_KNOWN_PATH_BASE = '.config';


### PR DESCRIPTION
The client library is already overriding *most* of these calls with the **v4** endpoint anyway (see [here](https://github.com/google/google-api-php-client/blob/master/src/Google/Client.php#L43)), so really leaving this as `v3` is scarier than upgrading it.