### PR TITLE
PSR-2 conversion & Docblock enrichment

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+charset = utf-8
+
+# Get rid of whitespace to avoid diffs with a bunch of EOL changes
+trim_trailing_whitespace = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# PHP-Files
+[*.php]
+indent_style = space
+indent_size = 4

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,54 @@
+<?php
+/**
+ * This file represents the configuration for Code Sniffing PSR-2-related
+ * automatic checks of coding guidelines
+ * Install @fabpot's great php-cs-fixer tool via
+ *
+ *  $ composer global require fabpot/php-cs-fixer
+ *
+ * And then simply run
+ *
+ *  $ php-cs-fixer fix --config-file .php_cs
+ *
+ * inside the root directory.
+ *
+ * 	 http://www.php-fig.org/psr/psr-2/
+ * 	 http://cs.sensiolabs.org
+ */
+
+if (PHP_SAPI !== 'cli') {
+    die('This script supports command line usage only. Please check your command.');
+}
+// Define in which folders to search and which folders to exclude
+// Exclude some directories that are excluded by Git anyways to speed up the sniffing
+$finder = Symfony\CS\Finder\DefaultFinder::create()
+    ->exclude('vendor')
+    ->in(__DIR__);
+
+// Return a Code Sniffing configuration using
+// all sniffers needed for PSR-2
+// and additionally:
+//  - Remove leading slashes in use clauses.
+//  - PHP single-line arrays should not have trailing comma.
+//  - Single-line whitespace before closing semicolon are prohibited.
+//  - Remove unused use statements in the PHP source code
+//  - Ensure Concatenation to have at least one whitespace around
+//  - Remove trailing whitespace at the end of blank lines.
+return Symfony\CS\Config\Config::create()
+    ->level(Symfony\CS\FixerInterface::PSR2_LEVEL)
+    ->fixers([
+        'remove_leading_slash_use',
+        'single_array_no_trailing_comma',
+        'spaces_before_semicolon',
+        'unused_use',
+        'concat_with_spaces',
+        'whitespacy_lines',
+        'ordered_use',
+        'single_quote',
+        'duplicate_semicolon',
+        'extra_empty_lines',
+        'phpdoc_no_package',
+        'phpdoc_scalar',
+        'no_empty_lines_after_phpdocs'
+    ])
+    ->finder($finder);

--- a/autoload.php
+++ b/autoload.php
@@ -15,19 +15,20 @@
  * limitations under the License.
  */
 
-function oauth2client_php_autoload($className) {
-  $classPath = explode('_', $className);
-  if ($classPath[0] != 'Google') {
-    return;
-  }
-  if (count($classPath) > 3) {
-    // Maximum class file path depth in this project is 3.
+function oauth2client_php_autoload($className)
+{
+    $classPath = explode('_', $className);
+    if ($classPath[0] != 'Google') {
+        return;
+    }
+    if (count($classPath) > 3) {
+        // Maximum class file path depth in this project is 3.
     $classPath = array_slice($classPath, 0, 3);
-  }
-  $filePath = dirname(__FILE__) . '/src/' . implode('/', $classPath) . '.php';
-  if (file_exists($filePath)) {
-    require_once($filePath);
-  }
+    }
+    $filePath = dirname(__FILE__) . '/src/' . implode('/', $classPath) . '.php';
+    if (file_exists($filePath)) {
+        require_once $filePath;
+    }
 }
 
 spl_autoload_register('oauth2client_php_autoload');

--- a/src/ApplicationDefaultCredentials.php
+++ b/src/ApplicationDefaultCredentials.php
@@ -17,6 +17,7 @@
 
 namespace Google\Auth;
 
+use DomainException;
 use Google\Auth\Credentials\AppIdentityCredentials;
 use Google\Auth\Credentials\GCECredentials;
 use Google\Auth\Middleware\AuthTokenMiddleware;
@@ -70,7 +71,9 @@ class ApplicationDefaultCredentials
      *   either as an Array or as a space-delimited String.
      * @param callable $httpHandler callback which delivers psr7 request
      * @param array $cacheConfig configuration for the cache when it's present
-     * @param object $cache an implementation of CacheInterface
+     * @param CacheInterface $cache an implementation of CacheInterface
+     *
+     * @return AuthTokenSubscriber
      *
      * @throws DomainException if no implementation can be obtained.
      */
@@ -95,8 +98,10 @@ class ApplicationDefaultCredentials
      * @param string|array scope the scope of the access request, expressed
      *   either as an Array or as a space-delimited String.
      * @param callable $httpHandler callback which delivers psr7 request
-     * @param cacheConfig configuration for the cache when it's present
-     * @param object $cache an implementation of CacheInterface
+     * @param array $cacheConfig configuration for the cache when it's present
+     * @param CacheInterface $cache
+     *
+     * @return AuthTokenMiddleware
      *
      * @throws DomainException if no implementation can be obtained.
      */
@@ -121,6 +126,8 @@ class ApplicationDefaultCredentials
      * @param string|array scope the scope of the access request, expressed
      *   either as an Array or as a space-delimited String.
      * @param callable $httpHandler callback which delivers psr7 request
+     *
+     * @return CredentialsLoader
      *
      * @throws DomainException if no implementation can be obtained.
      */

--- a/src/ApplicationDefaultCredentials.php
+++ b/src/ApplicationDefaultCredentials.php
@@ -59,96 +59,97 @@ use Google\Auth\Subscriber\AuthTokenSubscriber;
  */
 class ApplicationDefaultCredentials
 {
-  /**
-   * Obtains an AuthTokenSubscriber that uses the default FetchAuthTokenInterface
-   * implementation to use in this environment.
-   *
-   * If supplied, $scope is used to in creating the credentials instance if
-   * this does not fallback to the compute engine defaults.
-   *
-   * @param string|array scope the scope of the access request, expressed
-   *   either as an Array or as a space-delimited String.
-   * @param callable $httpHandler callback which delivers psr7 request
-   * @param array $cacheConfig configuration for the cache when it's present
-   * @param object $cache an implementation of CacheInterface
-   *
-   * @throws DomainException if no implementation can be obtained.
-   */
-  public static function getSubscriber(
-    $scope = null,
-    callable $httpHandler = null,
-    array $cacheConfig = null,
-    CacheInterface $cache = null
-  ) {
-    $creds = self::getCredentials($scope, $httpHandler);
+    /**
+     * Obtains an AuthTokenSubscriber that uses the default FetchAuthTokenInterface
+     * implementation to use in this environment.
+     *
+     * If supplied, $scope is used to in creating the credentials instance if
+     * this does not fallback to the compute engine defaults.
+     *
+     * @param string|array scope the scope of the access request, expressed
+     *   either as an Array or as a space-delimited String.
+     * @param callable $httpHandler callback which delivers psr7 request
+     * @param array $cacheConfig configuration for the cache when it's present
+     * @param object $cache an implementation of CacheInterface
+     *
+     * @throws DomainException if no implementation can be obtained.
+     */
+    public static function getSubscriber(
+        $scope = null,
+        callable $httpHandler = null,
+        array $cacheConfig = null,
+        CacheInterface $cache = null
+    ) {
+        $creds = self::getCredentials($scope, $httpHandler);
 
-    return new AuthTokenSubscriber($creds, $cacheConfig, $cache, $httpHandler);
-  }
-
-  /**
-   * Obtains an AuthTokenMiddleware that uses the default FetchAuthTokenInterface
-   * implementation to use in this environment.
-   *
-   * If supplied, $scope is used to in creating the credentials instance if
-   * this does not fallback to the compute engine defaults.
-   *
-   * @param string|array scope the scope of the access request, expressed
-   *   either as an Array or as a space-delimited String.
-   * @param callable $httpHandler callback which delivers psr7 request
-   * @param cacheConfig configuration for the cache when it's present
-   * @param object $cache an implementation of CacheInterface
-   *
-   * @throws DomainException if no implementation can be obtained.
-   */
-  public static function getMiddleware(
-    $scope = null,
-    callable $httpHandler = null,
-    array $cacheConfig = null,
-    CacheInterface $cache = null
-  ) {
-    $creds = self::getCredentials($scope, $httpHandler);
-
-    return new AuthTokenMiddleware($creds, $cacheConfig, $cache, $httpHandler);
-  }
-
-  /**
-   * Obtains the default FetchAuthTokenInterface implementation to use
-   * in this environment.
-   *
-   * If supplied, $scope is used to in creating the credentials instance if
-   * this does not fallback to the Compute Engine defaults.
-   *
-   * @param string|array scope the scope of the access request, expressed
-   *   either as an Array or as a space-delimited String.
-   *
-   * @param callable $httpHandler callback which delivers psr7 request
-   * @throws DomainException if no implementation can be obtained.
-   */
-  public static function getCredentials($scope = null, callable $httpHandler = null)
-  {
-    $creds = CredentialsLoader::fromEnv($scope);
-    if (!is_null($creds)) {
-      return $creds;
+        return new AuthTokenSubscriber($creds, $cacheConfig, $cache, $httpHandler);
     }
-    $creds = CredentialsLoader::fromWellKnownFile($scope);
-    if (!is_null($creds)) {
-      return $creds;
-    }
-    if (AppIdentityCredentials::onAppEngine()) {
-      return new AppIdentityCredentials($scope);
-    }
-    if (GCECredentials::onGce($httpHandler)) {
-      return new GCECredentials();
-    }
-    throw new \DomainException(self::notFound());
-  }
 
-  private static function notFound()
-  {
-    $msg = 'Could not load the default credentials. Browse to ';
-    $msg .= 'https://developers.google.com';
-    $msg .= '/accounts/docs/application-default-credentials';
-    $msg .= ' for more information' ;
-    return $msg;
-  }
+    /**
+     * Obtains an AuthTokenMiddleware that uses the default FetchAuthTokenInterface
+     * implementation to use in this environment.
+     *
+     * If supplied, $scope is used to in creating the credentials instance if
+     * this does not fallback to the compute engine defaults.
+     *
+     * @param string|array scope the scope of the access request, expressed
+     *   either as an Array or as a space-delimited String.
+     * @param callable $httpHandler callback which delivers psr7 request
+     * @param cacheConfig configuration for the cache when it's present
+     * @param object $cache an implementation of CacheInterface
+     *
+     * @throws DomainException if no implementation can be obtained.
+     */
+    public static function getMiddleware(
+        $scope = null,
+        callable $httpHandler = null,
+        array $cacheConfig = null,
+        CacheInterface $cache = null
+    ) {
+        $creds = self::getCredentials($scope, $httpHandler);
+
+        return new AuthTokenMiddleware($creds, $cacheConfig, $cache, $httpHandler);
+    }
+
+    /**
+     * Obtains the default FetchAuthTokenInterface implementation to use
+     * in this environment.
+     *
+     * If supplied, $scope is used to in creating the credentials instance if
+     * this does not fallback to the Compute Engine defaults.
+     *
+     * @param string|array scope the scope of the access request, expressed
+     *   either as an Array or as a space-delimited String.
+     * @param callable $httpHandler callback which delivers psr7 request
+     *
+     * @throws DomainException if no implementation can be obtained.
+     */
+    public static function getCredentials($scope = null, callable $httpHandler = null)
+    {
+        $creds = CredentialsLoader::fromEnv($scope);
+        if (!is_null($creds)) {
+            return $creds;
+        }
+        $creds = CredentialsLoader::fromWellKnownFile($scope);
+        if (!is_null($creds)) {
+            return $creds;
+        }
+        if (AppIdentityCredentials::onAppEngine()) {
+            return new AppIdentityCredentials($scope);
+        }
+        if (GCECredentials::onGce($httpHandler)) {
+            return new GCECredentials();
+        }
+        throw new \DomainException(self::notFound());
+    }
+
+    private static function notFound()
+    {
+        $msg = 'Could not load the default credentials. Browse to ';
+        $msg .= 'https://developers.google.com';
+        $msg .= '/accounts/docs/application-default-credentials';
+        $msg .= ' for more information';
+
+        return $msg;
+    }
 }

--- a/src/CacheInterface.php
+++ b/src/CacheInterface.php
@@ -22,30 +22,29 @@ namespace Google\Auth;
  */
 interface CacheInterface
 {
+    /**
+     * Retrieves the data for the given key, or false if the key is unknown or
+     * expired.
+     *
+     * @param string $key The key who's data to retrieve
+     * @param bool|int $expiration Expiration time in seconds
+     */
+    public function get($key, $expiration = false);
 
-  /**
-   * Retrieves the data for the given key, or false if the key is unknown or
-   * expired.
-   *
-   * @param String $key The key who's data to retrieve
-   * @param boolean|int $expiration Expiration time in seconds
-   */
-  public function get($key, $expiration = false);
+    /**
+     * Store the key => $value.
+     *
+     * Implementations will serialize $value.
+     *
+     * @param string $key the cachke key
+     * @param string $value data
+     */
+    public function set($key, $value);
 
-  /**
-   * Store the key => $value
-   *
-   * Implementations will serialize $value.
-   *
-   * @param string $key the cachke key
-   * @param string $value data
-   */
-  public function set($key, $value);
-
-  /**
-   * Removes the key/data pair.
-   *
-   * @param String $key
-   */
-  public function delete($key);
+    /**
+     * Removes the key/data pair.
+     *
+     * @param string $key
+     */
+    public function delete($key);
 }

--- a/src/CacheTrait.php
+++ b/src/CacheTrait.php
@@ -19,50 +19,50 @@ namespace Google\Auth;
 
 trait CacheTrait
 {
-  /**
-   * Gets the cached value if it is present in the cache when that is
-   * available.
-   */
-  private function getCachedValue()
-  {
-    if (is_null($this->cache)) {
-      return null;
+    /**
+     * Gets the cached value if it is present in the cache when that is
+     * available.
+     */
+    private function getCachedValue()
+    {
+        if (is_null($this->cache)) {
+            return;
+        }
+
+        if (isset($this->fetcher)) {
+            $fetcherKey = $this->fetcher->getCacheKey();
+        } else {
+            $fetcherKey = $this->getCacheKey();
+        }
+
+        if (is_null($fetcherKey)) {
+            return;
+        }
+
+        $key = $this->cacheConfig['prefix'].$fetcherKey;
+
+        return $this->cache->get($key, $this->cacheConfig['lifetime']);
     }
 
-    if (isset($this->fetcher)) {
-      $fetcherKey = $this->fetcher->getCacheKey();
-    } else {
-      $fetcherKey = $this->getCacheKey();
-    }
+    /**
+     * Saves the value in the cache when that is available.
+     */
+    private function setCachedValue($v)
+    {
+        if (is_null($this->cache)) {
+            return;
+        }
 
-    if (is_null($fetcherKey)) {
-      return null;
-    }
+        if (isset($this->fetcher)) {
+            $fetcherKey = $this->fetcher->getCacheKey();
+        } else {
+            $fetcherKey = $this->getCacheKey();
+        }
 
-    $key = $this->cacheConfig['prefix'] . $fetcherKey;
-    return $this->cache->get($key, $this->cacheConfig['lifetime']);
-  }
-
-  /**
-   * Saves the value in the cache when that is available.
-   */
-  private function setCachedValue($v)
-  {
-    if (is_null($this->cache)) {
-      return;
+        if (is_null($fetcherKey)) {
+            return;
+        }
+        $key = $this->cacheConfig['prefix'].$fetcherKey;
+        $this->cache->set($key, $v);
     }
-
-    if (isset($this->fetcher)) {
-      $fetcherKey = $this->fetcher->getCacheKey();
-    } else {
-      $fetcherKey = $this->getCacheKey();
-    }
-
-    if (is_null($fetcherKey)) {
-      return;
-    }
-    $key = $this->cacheConfig['prefix'] . $fetcherKey;
-    $this->cache->set($key, $v);
-  }
 }
-

--- a/src/Credentials/AppIdentityCredentials.php
+++ b/src/Credentials/AppIdentityCredentials.php
@@ -17,14 +17,13 @@
 
 namespace Google\Auth\Credentials;
 
-use Google\Auth\CredentialsLoader;
-
-/**
+use google\appengine\api\app_identity\AppIdentityService;
+/*
  * The AppIdentityService class is automatically defined on App Engine,
  * so including this dependency is not necessary, and will result in a
  * PHP fatal error in the App Engine environment.
  */
-use google\appengine\api\app_identity\AppIdentityService;
+use Google\Auth\CredentialsLoader;
 
 /**
  * AppIdentityCredentials supports authorization on Google App Engine.
@@ -52,93 +51,94 @@ use google\appengine\api\app_identity\AppIdentityService;
  */
 class AppIdentityCredentials extends CredentialsLoader
 {
-  /**
-   * Result of fetchAuthToken
-   */
-  protected $lastReceivedToken;
+    /**
+     * Result of fetchAuthToken.
+     */
+    protected $lastReceivedToken;
 
-  /**
-   * Array of OAuth2 scopes to be requested
-   */
-  private $scope;
+    /**
+     * Array of OAuth2 scopes to be requested.
+     */
+    private $scope;
 
-  public function __construct($scope = array())
-  {
-    $this->scope = $scope;
-  }
-
-  /**
-   * Determines if this an App Engine instance, by accessing the SERVER_SOFTWARE
-   * environment variable.
-   *
-   * @return true if this an App Engine Instance, false otherwise
-   */
-  public static function onAppEngine()
-  {
-    return (isset($_SERVER['SERVER_SOFTWARE']) &&
-        strpos($_SERVER['SERVER_SOFTWARE'], 'Google App Engine') !== false);
-  }
-
-  /**
-   * Implements FetchAuthTokenInterface#fetchAuthToken.
-   *
-   * Fetches the auth tokens using the AppIdentityService if available.
-   * As the AppIdentityService uses protobufs to fetch the access token,
-   * the GuzzleHttp\ClientInterface instance passed in will not be used.
-   *
-   * @param callable $httpHandler callback which delivers psr7 request
-   * @return array the auth metadata:
-   *  array(2) {
-   *   ["access_token"]=>
-   *   string(3) "xyz"
-   *   ["expiration_time"]=>
-   *   string(10) "1444339905"
-   *  }
-   */
-  public function fetchAuthToken(callable $httpHandler = null)
-  {
-    if (!self::onAppEngine()) {
-      return array();
+    public function __construct($scope = array())
+    {
+        $this->scope = $scope;
     }
 
-    if (!class_exists('google\appengine\api\app_identity\AppIdentityService')) {
-      throw new \Exception(
-        'This class must be run in App Engine, or you must include the AppIdentityService '
-        . 'mock class defined in tests/mocks/AppIdentityService.php'
-      );
+    /**
+     * Determines if this an App Engine instance, by accessing the SERVER_SOFTWARE
+     * environment variable.
+     *
+     * @return true if this an App Engine Instance, false otherwise
+     */
+    public static function onAppEngine()
+    {
+        return isset($_SERVER['SERVER_SOFTWARE']) &&
+        strpos($_SERVER['SERVER_SOFTWARE'], 'Google App Engine') !== false;
     }
 
-    // AppIdentityService expects an array when multiple scopes are supplied
-    $scope = is_array($this->scope) ? $this->scope : explode(' ', $this->scope);
+    /**
+     * Implements FetchAuthTokenInterface#fetchAuthToken.
+     *
+     * Fetches the auth tokens using the AppIdentityService if available.
+     * As the AppIdentityService uses protobufs to fetch the access token,
+     * the GuzzleHttp\ClientInterface instance passed in will not be used.
+     *
+     * @param callable $httpHandler callback which delivers psr7 request
+     *
+     * @return array the auth metadata:
+     *  array(2) {
+     *   ["access_token"]=>
+     *   string(3) "xyz"
+     *   ["expiration_time"]=>
+     *   string(10) "1444339905"
+     *  }
+     */
+    public function fetchAuthToken(callable $httpHandler = null)
+    {
+        if (!self::onAppEngine()) {
+            return array();
+        }
 
-    $token = AppIdentityService::getAccessToken($scope);
-    $this->lastReceivedToken = $token;
+        if (!class_exists('google\appengine\api\app_identity\AppIdentityService')) {
+            throw new \Exception(
+                'This class must be run in App Engine, or you must include the AppIdentityService '
+                .'mock class defined in tests/mocks/AppIdentityService.php'
+            );
+        }
 
-    return $token;
-  }
+        // AppIdentityService expects an array when multiple scopes are supplied
+        $scope = is_array($this->scope) ? $this->scope : explode(' ', $this->scope);
 
-  /**
-   * Implements FetchAuthTokenInterface#getLastReceivedToken.
-   */
-  public function getLastReceivedToken()
-  {
-    if ($this->lastReceivedToken) {
-      return [
-        'access_token' => $this->lastReceivedToken['access_token'],
-        'expires_at' => $this->lastReceivedToken['expiration_time'],
-      ];
+        $token = AppIdentityService::getAccessToken($scope);
+        $this->lastReceivedToken = $token;
+
+        return $token;
     }
 
-    return null;
-  }
+    /**
+     * Implements FetchAuthTokenInterface#getLastReceivedToken.
+     */
+    public function getLastReceivedToken()
+    {
+        if ($this->lastReceivedToken) {
+            return [
+                'access_token' => $this->lastReceivedToken['access_token'],
+                'expires_at' => $this->lastReceivedToken['expiration_time'],
+            ];
+        }
 
-  /**
-   * Implements FetchAuthTokenInterface#getCacheKey.
-   *
-   * @return 'GOOGLE_AUTH_PHP_APPIDENTITY'
-   */
-  public function getCacheKey()
-  {
-    return 'GOOGLE_AUTH_PHP_APPIDENTITY';
-  }
+        return;
+    }
+
+    /**
+     * Implements FetchAuthTokenInterface#getCacheKey.
+     *
+     * @return 'GOOGLE_AUTH_PHP_APPIDENTITY'
+     */
+    public function getCacheKey()
+    {
+        return 'GOOGLE_AUTH_PHP_APPIDENTITY';
+    }
 }

--- a/src/Credentials/AppIdentityCredentials.php
+++ b/src/Credentials/AppIdentityCredentials.php
@@ -17,12 +17,12 @@
 
 namespace Google\Auth\Credentials;
 
-use google\appengine\api\app_identity\AppIdentityService;
 /*
  * The AppIdentityService class is automatically defined on App Engine,
  * so including this dependency is not necessary, and will result in a
  * PHP fatal error in the App Engine environment.
  */
+use google\appengine\api\app_identity\AppIdentityService;
 use Google\Auth\CredentialsLoader;
 
 /**

--- a/src/Credentials/AppIdentityCredentials.php
+++ b/src/Credentials/AppIdentityCredentials.php
@@ -51,8 +51,12 @@ use Google\Auth\CredentialsLoader;
  */
 class AppIdentityCredentials extends CredentialsLoader
 {
+    const cacheKey = 'GOOGLE_AUTH_PHP_APPIDENTITY';
+
     /**
      * Result of fetchAuthToken.
+     *
+     * @array
      */
     protected $lastReceivedToken;
 
@@ -94,6 +98,8 @@ class AppIdentityCredentials extends CredentialsLoader
      *   ["expiration_time"]=>
      *   string(10) "1444339905"
      *  }
+     *
+     * @throws \Exception
      */
     public function fetchAuthToken(callable $httpHandler = null)
     {
@@ -118,7 +124,7 @@ class AppIdentityCredentials extends CredentialsLoader
     }
 
     /**
-     * Implements FetchAuthTokenInterface#getLastReceivedToken.
+     * @return array|null
      */
     public function getLastReceivedToken()
     {
@@ -129,16 +135,14 @@ class AppIdentityCredentials extends CredentialsLoader
             ];
         }
 
-        return;
+        return null;
     }
 
     /**
-     * Implements FetchAuthTokenInterface#getCacheKey.
-     *
-     * @return 'GOOGLE_AUTH_PHP_APPIDENTITY'
+     * @return string
      */
     public function getCacheKey()
     {
-        return 'GOOGLE_AUTH_PHP_APPIDENTITY';
+        return self::cacheKey;
     }
 }

--- a/src/Credentials/GCECredentials.php
+++ b/src/Credentials/GCECredentials.php
@@ -50,6 +50,7 @@ use GuzzleHttp\Psr7\Request;
  */
 class GCECredentials extends CredentialsLoader
 {
+    const cacheKey = 'GOOGLE_AUTH_PHP_GCE';
     /**
      * The metadata IP address on appengine instances.
      *
@@ -70,11 +71,15 @@ class GCECredentials extends CredentialsLoader
 
     /**
      * Flag used to ensure that the onGCE test is only done once;.
+     *
+     * @var bool
      */
     private $hasCheckedOnGce = false;
 
     /**
      * Flag that stores the value of the onGCE check.
+     *
+     * @var bool
      */
     private $isOnGce = false;
 
@@ -85,6 +90,8 @@ class GCECredentials extends CredentialsLoader
 
     /**
      * The full uri for accessing the default token.
+     *
+     * @return string
      */
     public static function getTokenUri()
     {
@@ -141,6 +148,8 @@ class GCECredentials extends CredentialsLoader
      * @param callable $httpHandler callback which delivers psr7 request
      *
      * @return array the response
+     *
+     * @throws \Exception
      */
     public function fetchAuthToken(callable $httpHandler = null)
     {
@@ -175,17 +184,15 @@ class GCECredentials extends CredentialsLoader
     }
 
     /**
-     * Implements FetchAuthTokenInterface#getCacheKey.
-     *
-     * @return 'GOOGLE_AUTH_PHP_GCE'
+     * @return string
      */
     public function getCacheKey()
     {
-        return 'GOOGLE_AUTH_PHP_GCE';
+        return self::cacheKey;
     }
 
     /**
-     * Implements FetchAuthTokenInterface#getLastReceivedToken.
+     * @return array|null
      */
     public function getLastReceivedToken()
     {
@@ -196,6 +203,6 @@ class GCECredentials extends CredentialsLoader
             ];
         }
 
-        return;
+        return null;
     }
 }

--- a/src/Credentials/IAMCredentials.php
+++ b/src/Credentials/IAMCredentials.php
@@ -18,64 +18,65 @@
 namespace Google\Auth\Credentials;
 
 /**
- * Authenticates requests using IAM credentials
+ * Authenticates requests using IAM credentials.
  */
 class IAMCredentials
 {
-  const SELECTOR_KEY = 'x-goog-iam-authority-selector';
-  const TOKEN_KEY = 'x-goog-iam-authorization-token';
+    const SELECTOR_KEY = 'x-goog-iam-authority-selector';
+    const TOKEN_KEY = 'x-goog-iam-authorization-token';
 
-  private $selector;
-  private $token;
+    private $selector;
+    private $token;
 
-  /**
-   * @param $selector string the IAM selector
-   * @param $token string the IAM token
-   */
-  public function __construct($selector, $token)
-  {
-    if (!is_string($selector)) {
-      throw new \InvalidArgumentException(
-          'selector must be a string');
+    /**
+     * @param $selector string the IAM selector
+     * @param $token string the IAM token
+     */
+    public function __construct($selector, $token)
+    {
+        if (!is_string($selector)) {
+            throw new \InvalidArgumentException(
+                'selector must be a string');
+        }
+        if (!is_string($token)) {
+            throw new \InvalidArgumentException(
+                'token must be a string');
+        }
+
+        $this->selector = $selector;
+        $this->token = $token;
     }
-    if (!is_string($token)) {
-      throw new \InvalidArgumentException(
-          'token must be a string');
+
+    /**
+     * export a callback function which updates runtime metadata.
+     *
+     * @return an updateMetadata function
+     */
+    public function getUpdateMetadataFunc()
+    {
+        return array($this, 'updateMetadata');
     }
 
-    $this->selector = $selector;
-    $this->token = $token;
-  }
+    /**
+     * Updates metadata with the appropriate header metadata.
+     *
+     * @param array $metadata metadata hashmap
+     * @param string $unusedAuthUri optional auth uri
+     * @param callable $httpHandler callback which delivers psr7 request
+     *        Note: this param is unused here, only included here for
+     *        consistency with other credentials class
+     *
+     * @return array updated metadata hashmap
+     */
+    public function updateMetadata(
+        $metadata,
+        $unusedAuthUri = null,
+        callable $httpHandler = null
+    ) {
+        $metadata_copy = $metadata;
+        $metadata_copy[self::SELECTOR_KEY] = $this->selector;
+        $metadata_copy[self::TOKEN_KEY] = $this->token;
 
-  /**
-   * export a callback function which updates runtime metadata
-   *
-   * @return an updateMetadata function
-   */
-  public function getUpdateMetadataFunc()
-  {
-    return array($this, 'updateMetadata');
-  }
-
-  /**
-   * Updates metadata with the appropriate header metadata
-   *
-   * @param array $metadata metadata hashmap
-   * @param string $unusedAuthUri optional auth uri
-   * @param callable $httpHandler callback which delivers psr7 request
-   *        Note: this param is unused here, only included here for
-   *        consistency with other credentials class
-   *
-   * @return array updated metadata hashmap
-   */
-  public function updateMetadata(
-    $metadata,
-    $unusedAuthUri = null,
-    callable $httpHandler = null
-  ) {
-    $metadata_copy = $metadata;
-    $metadata_copy[self::SELECTOR_KEY] = $this->selector;
-    $metadata_copy[self::TOKEN_KEY] = $this->token;
-    return $metadata_copy;
-  }
+        return $metadata_copy;
+    }
 }

--- a/src/Credentials/IAMCredentials.php
+++ b/src/Credentials/IAMCredentials.php
@@ -25,7 +25,14 @@ class IAMCredentials
     const SELECTOR_KEY = 'x-goog-iam-authority-selector';
     const TOKEN_KEY = 'x-goog-iam-authorization-token';
 
+    /**
+     * @var string
+     */
     private $selector;
+
+    /**
+     * @var string
+     */
     private $token;
 
     /**
@@ -50,7 +57,7 @@ class IAMCredentials
     /**
      * export a callback function which updates runtime metadata.
      *
-     * @return an updateMetadata function
+     * @return array updateMetadata function
      */
     public function getUpdateMetadataFunc()
     {

--- a/src/Credentials/ServiceAccountCredentials.php
+++ b/src/Credentials/ServiceAccountCredentials.php
@@ -55,119 +55,119 @@ use Google\Auth\OAuth2;
  */
 class ServiceAccountCredentials extends CredentialsLoader
 {
-  /**
-   * The OAuth2 instance used to conduct authorization.
-   */
-  protected $auth;
+    /**
+     * The OAuth2 instance used to conduct authorization.
+     */
+    protected $auth;
 
-  /**
-   * Create a new ServiceAccountCredentials.
-   *
-   * @param string|array $scope the scope of the access request, expressed
-   *   either as an Array or as a space-delimited String.
-   *
-   * @param string|array $jsonKey JSON credential file path or JSON credentials
-   *   as an associative array
-   *
-   * @param string $sub an email address account to impersonate, in situations when
-   *   the service account has been delegated domain wide access.
-   */
-  public function __construct(
-    $scope,
-    $jsonKey,
-    $sub = null
-  ) {
-    if (is_string($jsonKey)) {
-      if (!file_exists($jsonKey)) {
-        throw new \InvalidArgumentException('file does not exist');
-      }
-      $jsonKeyStream = file_get_contents($jsonKey);
-      if (!$jsonKey = json_decode($jsonKeyStream, true)) {
-        throw new \LogicException('invalid json for auth config');
-      }
-    }
-    if (!array_key_exists('client_email', $jsonKey)) {
-      throw new \InvalidArgumentException(
-          'json key is missing the client_email field');
-    }
-    if (!array_key_exists('private_key', $jsonKey)) {
-      throw new \InvalidArgumentException(
-          'json key is missing the private_key field');
-    }
-    $this->auth = new OAuth2([
-        'audience' => self::TOKEN_CREDENTIAL_URI,
-        'issuer' => $jsonKey['client_email'],
-        'scope' => $scope,
-        'signingAlgorithm' => 'RS256',
-        'signingKey' => $jsonKey['private_key'],
-        'sub' => $sub,
-        'tokenCredentialUri' => self::TOKEN_CREDENTIAL_URI
-    ]);
-  }
-
-  /**
-   * Implements FetchAuthTokenInterface#fetchAuthToken.
-   */
-  public function fetchAuthToken(callable $httpHandler = null)
-  {
-    return $this->auth->fetchAuthToken($httpHandler);
-  }
-
- /**
-  * Implements FetchAuthTokenInterface#getCacheKey.
-  */
-  public function getCacheKey()
-  {
-    $key = $this->auth->getIssuer() . ':' . $this->auth->getCacheKey();
-    if ($sub = $this->auth->getSub()) {
-      $key .= ':' . $sub;
-    }
-    return $key;
-  }
-
-  /**
-   * Implements FetchAuthTokenInterface#getLastReceivedToken.
-   */
-  public function getLastReceivedToken()
-  {
-    return $this->auth->getLastReceivedToken();
-  }
-
-  /**
-   * Updates metadata with the authorization token
-   *
-   * @param array $metadata metadata hashmap
-   * @param string $authUri optional auth uri
-   * @param callable $httpHandler callback which delivers psr7 request
-   *
-   * @return array updated metadata hashmap
-   */
-  public function updateMetadata(
-    $metadata,
-    $authUri = null,
-    callable $httpHandler = null
-  ) {
-    // scope exists. use oauth implementation
-    $scope = $this->auth->getScope();
-    if (!is_null($scope)) {
-      return parent::updateMetadata($metadata, $authUri, $httpHandler);
+    /**
+     * Create a new ServiceAccountCredentials.
+     *
+     * @param string|array $scope the scope of the access request, expressed
+     *   either as an Array or as a space-delimited String.
+     * @param string|array $jsonKey JSON credential file path or JSON credentials
+     *   as an associative array
+     * @param string $sub an email address account to impersonate, in situations when
+     *   the service account has been delegated domain wide access.
+     */
+    public function __construct(
+        $scope,
+        $jsonKey,
+        $sub = null
+    ) {
+        if (is_string($jsonKey)) {
+            if (!file_exists($jsonKey)) {
+                throw new \InvalidArgumentException('file does not exist');
+            }
+            $jsonKeyStream = file_get_contents($jsonKey);
+            if (!$jsonKey = json_decode($jsonKeyStream, true)) {
+                throw new \LogicException('invalid json for auth config');
+            }
+        }
+        if (!array_key_exists('client_email', $jsonKey)) {
+            throw new \InvalidArgumentException(
+                'json key is missing the client_email field');
+        }
+        if (!array_key_exists('private_key', $jsonKey)) {
+            throw new \InvalidArgumentException(
+                'json key is missing the private_key field');
+        }
+        $this->auth = new OAuth2([
+            'audience' => self::TOKEN_CREDENTIAL_URI,
+            'issuer' => $jsonKey['client_email'],
+            'scope' => $scope,
+            'signingAlgorithm' => 'RS256',
+            'signingKey' => $jsonKey['private_key'],
+            'sub' => $sub,
+            'tokenCredentialUri' => self::TOKEN_CREDENTIAL_URI,
+        ]);
     }
 
-    // no scope found. create jwt with the auth uri
-    $credJson = array(
-      'private_key' => $this->auth->getSigningKey(),
-      'client_email' => $this->auth->getIssuer(),
-    );
-    $jwtCreds = new ServiceAccountJwtAccessCredentials($credJson);
-    return $jwtCreds->updateMetadata($metadata, $authUri, $httpHandler);
-  }
+    /**
+     * Implements FetchAuthTokenInterface#fetchAuthToken.
+     */
+    public function fetchAuthToken(callable $httpHandler = null)
+    {
+        return $this->auth->fetchAuthToken($httpHandler);
+    }
 
-  /**
-   * @param string $sub an email address account to impersonate, in situations when
-   *   the service account has been delegated domain wide access.
-   */
-  public function setSub($sub)
-  {
-    $this->auth->setSub($sub);
-  }
+    /**
+     * Implements FetchAuthTokenInterface#getCacheKey.
+     */
+    public function getCacheKey()
+    {
+        $key = $this->auth->getIssuer().':'.$this->auth->getCacheKey();
+        if ($sub = $this->auth->getSub()) {
+            $key .= ':'.$sub;
+        }
+
+        return $key;
+    }
+
+    /**
+     * Implements FetchAuthTokenInterface#getLastReceivedToken.
+     */
+    public function getLastReceivedToken()
+    {
+        return $this->auth->getLastReceivedToken();
+    }
+
+    /**
+     * Updates metadata with the authorization token.
+     *
+     * @param array $metadata metadata hashmap
+     * @param string $authUri optional auth uri
+     * @param callable $httpHandler callback which delivers psr7 request
+     *
+     * @return array updated metadata hashmap
+     */
+    public function updateMetadata(
+        $metadata,
+        $authUri = null,
+        callable $httpHandler = null
+    ) {
+        // scope exists. use oauth implementation
+        $scope = $this->auth->getScope();
+        if (!is_null($scope)) {
+            return parent::updateMetadata($metadata, $authUri, $httpHandler);
+        }
+
+        // no scope found. create jwt with the auth uri
+        $credJson = array(
+            'private_key' => $this->auth->getSigningKey(),
+            'client_email' => $this->auth->getIssuer(),
+        );
+        $jwtCreds = new ServiceAccountJwtAccessCredentials($credJson);
+
+        return $jwtCreds->updateMetadata($metadata, $authUri, $httpHandler);
+    }
+
+    /**
+     * @param string $sub an email address account to impersonate, in situations when
+     *   the service account has been delegated domain wide access.
+     */
+    public function setSub($sub)
+    {
+        $this->auth->setSub($sub);
+    }
 }

--- a/src/Credentials/ServiceAccountCredentials.php
+++ b/src/Credentials/ServiceAccountCredentials.php
@@ -57,6 +57,8 @@ class ServiceAccountCredentials extends CredentialsLoader
 {
     /**
      * The OAuth2 instance used to conduct authorization.
+     *
+     * @var OAuth2
      */
     protected $auth;
 
@@ -104,7 +106,9 @@ class ServiceAccountCredentials extends CredentialsLoader
     }
 
     /**
-     * Implements FetchAuthTokenInterface#fetchAuthToken.
+     * @param callable $httpHandler
+     *
+     * @return array
      */
     public function fetchAuthToken(callable $httpHandler = null)
     {
@@ -112,7 +116,7 @@ class ServiceAccountCredentials extends CredentialsLoader
     }
 
     /**
-     * Implements FetchAuthTokenInterface#getCacheKey.
+     * @return string
      */
     public function getCacheKey()
     {
@@ -125,7 +129,7 @@ class ServiceAccountCredentials extends CredentialsLoader
     }
 
     /**
-     * Implements FetchAuthTokenInterface#getLastReceivedToken.
+     * @return array
      */
     public function getLastReceivedToken()
     {

--- a/src/Credentials/ServiceAccountJwtAccessCredentials.php
+++ b/src/Credentials/ServiceAccountJwtAccessCredentials.php
@@ -31,93 +31,95 @@ use Google\Auth\OAuth2;
  */
 class ServiceAccountJwtAccessCredentials extends CredentialsLoader
 {
+    /**
+     * The OAuth2 instance used to conduct authorization.
+     */
+    protected $auth;
 
-  /**
-   * The OAuth2 instance used to conduct authorization.
-   */
-  protected $auth;
-
-  /**
-   * Create a new ServiceAccountJwtAccessCredentials.
-   *
-   * @param string|array $jsonKey JSON credential file path or JSON credentials
-   *   as an associative array
-   */
-  public function __construct($jsonKey) {
-    if (is_string($jsonKey)) {
-      if (!file_exists($jsonKey)) {
-        throw new \InvalidArgumentException('file does not exist');
-      }
-      $jsonKeyStream = file_get_contents($jsonKey);
-      if (!$jsonKey = json_decode($jsonKeyStream, true)) {
-        throw new \LogicException('invalid json for auth config');
-      }
-    }
-    if (!array_key_exists('client_email', $jsonKey)) {
-      throw new \InvalidArgumentException(
-          'json key is missing the client_email field');
-    }
-    if (!array_key_exists('private_key', $jsonKey)) {
-      throw new \InvalidArgumentException(
-          'json key is missing the private_key field');
-    }
-    $this->auth = new OAuth2([
-      'issuer' => $jsonKey['client_email'],
-      'sub' => $jsonKey['client_email'],
-      'signingAlgorithm' => 'RS256',
-      'signingKey' => $jsonKey['private_key'],
-    ]);
-  }
-
-  /**
-   * Updates metadata with the authorization token
-   *
-   * @param array $metadata metadata hashmap
-   * @param string $authUri optional auth uri
-   * @param callable $httpHandler callback which delivers psr7 request
-   *
-   * @return array updated metadata hashmap
-   */
-  public function updateMetadata(
-    $metadata,
-    $authUri = null,
-    callable $httpHandler = null
-  ) {
-    if (empty($authUri)) {
-      return $metadata;
+    /**
+     * Create a new ServiceAccountJwtAccessCredentials.
+     *
+     * @param string|array $jsonKey JSON credential file path or JSON credentials
+     *   as an associative array
+     */
+    public function __construct($jsonKey)
+    {
+        if (is_string($jsonKey)) {
+            if (!file_exists($jsonKey)) {
+                throw new \InvalidArgumentException('file does not exist');
+            }
+            $jsonKeyStream = file_get_contents($jsonKey);
+            if (!$jsonKey = json_decode($jsonKeyStream, true)) {
+                throw new \LogicException('invalid json for auth config');
+            }
+        }
+        if (!array_key_exists('client_email', $jsonKey)) {
+            throw new \InvalidArgumentException(
+                'json key is missing the client_email field');
+        }
+        if (!array_key_exists('private_key', $jsonKey)) {
+            throw new \InvalidArgumentException(
+                'json key is missing the private_key field');
+        }
+        $this->auth = new OAuth2([
+            'issuer' => $jsonKey['client_email'],
+            'sub' => $jsonKey['client_email'],
+            'signingAlgorithm' => 'RS256',
+            'signingKey' => $jsonKey['private_key'],
+        ]);
     }
 
-    $this->auth->setAudience($authUri);
-    return parent::updateMetadata($metadata, $authUri, $httpHandler);
-  }
+    /**
+     * Updates metadata with the authorization token.
+     *
+     * @param array $metadata metadata hashmap
+     * @param string $authUri optional auth uri
+     * @param callable $httpHandler callback which delivers psr7 request
+     *
+     * @return array updated metadata hashmap
+     */
+    public function updateMetadata(
+        $metadata,
+        $authUri = null,
+        callable $httpHandler = null
+    ) {
+        if (empty($authUri)) {
+            return $metadata;
+        }
 
- /**
-  * Implements FetchAuthTokenInterface#fetchAuthToken.
-  */
-  public function fetchAuthToken(callable $httpHandler = null)
-  {
-    $audience = $this->auth->getAudience();
-    if (empty($audience)) {
-      return null;
+        $this->auth->setAudience($authUri);
+
+        return parent::updateMetadata($metadata, $authUri, $httpHandler);
     }
 
-    $access_token = $this->auth->toJwt();
-    return array('access_token' => $access_token);
-  }
+    /**
+     * Implements FetchAuthTokenInterface#fetchAuthToken.
+     */
+    public function fetchAuthToken(callable $httpHandler = null)
+    {
+        $audience = $this->auth->getAudience();
+        if (empty($audience)) {
+            return;
+        }
 
-  /**
-   * Implements FetchAuthTokenInterface#getCacheKey.
-   */
-  public function getCacheKey()
-  {
-    return $this->auth->getCacheKey();
-  }
+        $access_token = $this->auth->toJwt();
 
-  /**
-   * Implements FetchAuthTokenInterface#getLastReceivedToken.
-   */
-  public function getLastReceivedToken()
-  {
-    return $this->auth->getLastReceivedToken();
-  }
+        return array('access_token' => $access_token);
+    }
+
+    /**
+     * Implements FetchAuthTokenInterface#getCacheKey.
+     */
+    public function getCacheKey()
+    {
+        return $this->auth->getCacheKey();
+    }
+
+    /**
+     * Implements FetchAuthTokenInterface#getLastReceivedToken.
+     */
+    public function getLastReceivedToken()
+    {
+        return $this->auth->getLastReceivedToken();
+    }
 }

--- a/src/Credentials/ServiceAccountJwtAccessCredentials.php
+++ b/src/Credentials/ServiceAccountJwtAccessCredentials.php
@@ -33,6 +33,8 @@ class ServiceAccountJwtAccessCredentials extends CredentialsLoader
 {
     /**
      * The OAuth2 instance used to conduct authorization.
+     *
+     * @var OAuth2
      */
     protected $auth;
 
@@ -94,12 +96,16 @@ class ServiceAccountJwtAccessCredentials extends CredentialsLoader
 
     /**
      * Implements FetchAuthTokenInterface#fetchAuthToken.
+     *
+     * @param callable $httpHandler
+     *
+     * @return array|void
      */
     public function fetchAuthToken(callable $httpHandler = null)
     {
         $audience = $this->auth->getAudience();
         if (empty($audience)) {
-            return;
+            return null;
         }
 
         $access_token = $this->auth->toJwt();
@@ -108,7 +114,7 @@ class ServiceAccountJwtAccessCredentials extends CredentialsLoader
     }
 
     /**
-     * Implements FetchAuthTokenInterface#getCacheKey.
+     * @return string
      */
     public function getCacheKey()
     {
@@ -116,7 +122,7 @@ class ServiceAccountJwtAccessCredentials extends CredentialsLoader
     }
 
     /**
-     * Implements FetchAuthTokenInterface#getLastReceivedToken.
+     * @return array
      */
     public function getLastReceivedToken()
     {

--- a/src/Credentials/UserRefreshCredentials.php
+++ b/src/Credentials/UserRefreshCredentials.php
@@ -29,12 +29,14 @@ use Google\Auth\OAuth2;
  * 'gcloud auth login' saves a file with these contents in well known
  * location
  *
- * cf [Application Default Credentials](http://goo.gl/mkAHpZ)
+ * @see [Application Default Credentials](http://goo.gl/mkAHpZ)
  */
 class UserRefreshCredentials extends CredentialsLoader
 {
     /**
      * The OAuth2 instance used to conduct authorization.
+     *
+     * @var OAuth2
      */
     protected $auth;
 
@@ -81,7 +83,9 @@ class UserRefreshCredentials extends CredentialsLoader
     }
 
     /**
-     * Implements FetchAuthTokenInterface#fetchAuthToken.
+     * @param callable $httpHandler
+     *
+     * @return array
      */
     public function fetchAuthToken(callable $httpHandler = null)
     {
@@ -89,7 +93,7 @@ class UserRefreshCredentials extends CredentialsLoader
     }
 
     /**
-     * Implements FetchAuthTokenInterface#getCacheKey.
+     * @return string
      */
     public function getCacheKey()
     {
@@ -97,7 +101,7 @@ class UserRefreshCredentials extends CredentialsLoader
     }
 
     /**
-     * Implements FetchAuthTokenInterface#getLastReceivedToken.
+     * @return array
      */
     public function getLastReceivedToken()
     {

--- a/src/Credentials/UserRefreshCredentials.php
+++ b/src/Credentials/UserRefreshCredentials.php
@@ -33,75 +33,74 @@ use Google\Auth\OAuth2;
  */
 class UserRefreshCredentials extends CredentialsLoader
 {
-  /**
-   * The OAuth2 instance used to conduct authorization.
-   */
-  protected $auth;
+    /**
+     * The OAuth2 instance used to conduct authorization.
+     */
+    protected $auth;
 
-  /**
-   * Create a new UserRefreshCredentials.
-   *
-   * @param string|array $scope the scope of the access request, expressed
-   *   either as an Array or as a space-delimited String.
-   *
-   * @param string|array $jsonKey JSON credential file path or JSON credentials
-   *   as an associative array
-   */
-  public function __construct(
-    $scope,
-    $jsonKey
-  ) {
-    if (is_string($jsonKey)) {
-      if (!file_exists($jsonKey)) {
-        throw new \InvalidArgumentException('file does not exist');
-      }
-      $jsonKeyStream = file_get_contents($jsonKey);
-      if (!$jsonKey = json_decode($jsonKeyStream, true)) {
-        throw new \LogicException('invalid json for auth config');
-      }
+    /**
+     * Create a new UserRefreshCredentials.
+     *
+     * @param string|array $scope the scope of the access request, expressed
+     *   either as an Array or as a space-delimited String.
+     * @param string|array $jsonKey JSON credential file path or JSON credentials
+     *   as an associative array
+     */
+    public function __construct(
+        $scope,
+        $jsonKey
+    ) {
+        if (is_string($jsonKey)) {
+            if (!file_exists($jsonKey)) {
+                throw new \InvalidArgumentException('file does not exist');
+            }
+            $jsonKeyStream = file_get_contents($jsonKey);
+            if (!$jsonKey = json_decode($jsonKeyStream, true)) {
+                throw new \LogicException('invalid json for auth config');
+            }
+        }
+        if (!array_key_exists('client_id', $jsonKey)) {
+            throw new \InvalidArgumentException(
+                'json key is missing the client_id field');
+        }
+        if (!array_key_exists('client_secret', $jsonKey)) {
+            throw new \InvalidArgumentException(
+                'json key is missing the client_secret field');
+        }
+        if (!array_key_exists('refresh_token', $jsonKey)) {
+            throw new \InvalidArgumentException(
+                'json key is missing the refresh_token field');
+        }
+        $this->auth = new OAuth2([
+            'clientId' => $jsonKey['client_id'],
+            'clientSecret' => $jsonKey['client_secret'],
+            'refresh_token' => $jsonKey['refresh_token'],
+            'scope' => $scope,
+            'tokenCredentialUri' => self::TOKEN_CREDENTIAL_URI,
+        ]);
     }
-    if (!array_key_exists('client_id', $jsonKey)) {
-      throw new \InvalidArgumentException(
-          'json key is missing the client_id field');
-    }
-    if (!array_key_exists('client_secret', $jsonKey)) {
-      throw new \InvalidArgumentException(
-          'json key is missing the client_secret field');
-    }
-    if (!array_key_exists('refresh_token', $jsonKey)) {
-      throw new \InvalidArgumentException(
-          'json key is missing the refresh_token field');
-    }
-    $this->auth = new OAuth2([
-        'clientId' => $jsonKey['client_id'],
-        'clientSecret' => $jsonKey['client_secret'],
-        'refresh_token' => $jsonKey['refresh_token'],
-        'scope' => $scope,
-        'tokenCredentialUri' => self::TOKEN_CREDENTIAL_URI
-    ]);
-  }
 
-  /**
-   * Implements FetchAuthTokenInterface#fetchAuthToken.
-   */
-  public function fetchAuthToken(callable $httpHandler = null)
-  {
-    return $this->auth->fetchAuthToken($httpHandler);
-  }
+    /**
+     * Implements FetchAuthTokenInterface#fetchAuthToken.
+     */
+    public function fetchAuthToken(callable $httpHandler = null)
+    {
+        return $this->auth->fetchAuthToken($httpHandler);
+    }
 
- /**
-  * Implements FetchAuthTokenInterface#getCacheKey.
-  */
-  public function getCacheKey()
-  {
-    return $this->auth->getClientId() . ':' . $this->auth->getCacheKey();
-  }
+    /**
+     * Implements FetchAuthTokenInterface#getCacheKey.
+     */
+    public function getCacheKey()
+    {
+        return $this->auth->getClientId().':'.$this->auth->getCacheKey();
+    }
 
-  /**
-   * Implements FetchAuthTokenInterface#getLastReceivedToken.
-   */
-  public function getLastReceivedToken()
-  {
-    return $this->auth->getLastReceivedToken();
-  }
+    /**
+     * Implements FetchAuthTokenInterface#getLastReceivedToken.
+     */
+    public function getLastReceivedToken()
+    {
+        return $this->auth->getLastReceivedToken();
+    }
 }

--- a/src/CredentialsLoader.php
+++ b/src/CredentialsLoader.php
@@ -28,140 +28,140 @@ use Psr\Http\Message\StreamInterface;
  */
 abstract class CredentialsLoader implements FetchAuthTokenInterface
 {
-  const TOKEN_CREDENTIAL_URI = 'https://www.googleapis.com/oauth2/v4/token';
-  const ENV_VAR = 'GOOGLE_APPLICATION_CREDENTIALS';
-  const WELL_KNOWN_PATH = 'gcloud/application_default_credentials.json';
-  const NON_WINDOWS_WELL_KNOWN_PATH_BASE = '.config';
-  const AUTH_METADATA_KEY = 'Authorization';
+    const TOKEN_CREDENTIAL_URI = 'https://www.googleapis.com/oauth2/v4/token';
+    const ENV_VAR = 'GOOGLE_APPLICATION_CREDENTIALS';
+    const WELL_KNOWN_PATH = 'gcloud/application_default_credentials.json';
+    const NON_WINDOWS_WELL_KNOWN_PATH_BASE = '.config';
+    const AUTH_METADATA_KEY = 'Authorization';
 
-  private static function unableToReadEnv($cause)
-  {
-    $msg = 'Unable to read the credential file specified by ';
-    $msg .= ' GOOGLE_APPLICATION_CREDENTIALS: ';
-    $msg .= $cause;
-    return $msg;
-  }
+    private static function unableToReadEnv($cause)
+    {
+        $msg = 'Unable to read the credential file specified by ';
+        $msg .= ' GOOGLE_APPLICATION_CREDENTIALS: ';
+        $msg .= $cause;
 
-  private static function isOnWindows()
-  {
-    return strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
-  }
-
-  /**
-   * Create a credentials instance from the path specified in the environment.
-   *
-   * Creates a credentials instance from the path specified in the environment
-   * variable GOOGLE_APPLICATION_CREDENTIALS. Return null if
-   * GOOGLE_APPLICATION_CREDENTIALS is not specified.
-   *
-   * @param string|array scope the scope of the access request, expressed
-   *   either as an Array or as a space-delimited String.
-   *
-   * @return a Credentials instance | null
-   */
-  public static function fromEnv($scope = null)
-  {
-    $path = getenv(self::ENV_VAR);
-    if (empty($path)) {
-      return null;
-    }
-    if (!file_exists($path)) {
-      $cause = "file " . $path . " does not exist";
-      throw new \DomainException(self::unableToReadEnv($cause));
-    }
-    $keyStream = Psr7\stream_for(file_get_contents($path));
-    return static::makeCredentials($scope, $keyStream);
-  }
-
-  /**
-   * Create a credentials instance from a well known path.
-   *
-   * The well known path is OS dependent:
-   * - windows: %APPDATA%/gcloud/application_default_credentials.json
-   * - others: $HOME/.config/gcloud/application_default_credentials.json
-   *
-   * If the file does not exists, this returns null.
-   *
-   * @param string|array scope the scope of the access request, expressed
-   *   either as an Array or as a space-delimited String.
-   *
-   * @return a Credentials instance | null
-   */
-  public static function fromWellKnownFile($scope = null)
-  {
-    $rootEnv = self::isOnWindows() ? 'APPDATA' : 'HOME';
-    $path = [getenv($rootEnv)];
-    if (!self::isOnWindows()) {
-      $path[] = self::NON_WINDOWS_WELL_KNOWN_PATH_BASE;
-    }
-    $path[] = self::WELL_KNOWN_PATH;
-    $path = join(DIRECTORY_SEPARATOR, $path);
-    if (!file_exists($path)) {
-      return null;
-    }
-    $keyStream = Psr7\stream_for(file_get_contents($path));
-    return static::makeCredentials($scope, $keyStream);
-  }
-
-  /**
-   * Create a new Credentials instance.
-   *
-   * @param string|array scope the scope of the access request, expressed
-   *   either as an Array or as a space-delimited String.
-   *
-   * @param StreamInterface jsonKeyStream read it to get the JSON credentials.
-   *
-   */
-  public static function makeCredentials($scope, StreamInterface $jsonKeyStream)
-  {
-    $jsonKey = json_decode($jsonKeyStream->getContents(), true);
-    if (!array_key_exists('type', $jsonKey)) {
-      throw new \InvalidArgumentException(
-          'json key is missing the type field');
+        return $msg;
     }
 
-    if ($jsonKey['type'] == 'service_account') {
-      return new ServiceAccountCredentials($scope, $jsonKey);
-
-    } else if ($jsonKey['type'] == 'authorized_user') {
-      return new UserRefreshCredentials($scope, $jsonKey);
-
-    } else {
-      throw new \InvalidArgumentException(
-          'invalid value in the type field');
+    private static function isOnWindows()
+    {
+        return strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
     }
-  }
 
-  /**
-   * export a callback function which updates runtime metadata
-   *
-   * @return an updateMetadata function
-   */
-  public function getUpdateMetadataFunc()
-  {
-    return array($this, 'updateMetadata');
-  }
+    /**
+     * Create a credentials instance from the path specified in the environment.
+     *
+     * Creates a credentials instance from the path specified in the environment
+     * variable GOOGLE_APPLICATION_CREDENTIALS. Return null if
+     * GOOGLE_APPLICATION_CREDENTIALS is not specified.
+     *
+     * @param string|array scope the scope of the access request, expressed
+     *   either as an Array or as a space-delimited String.
+     *
+     * @return a Credentials instance | null
+     */
+    public static function fromEnv($scope = null)
+    {
+        $path = getenv(self::ENV_VAR);
+        if (empty($path)) {
+            return;
+        }
+        if (!file_exists($path)) {
+            $cause = 'file '.$path.' does not exist';
+            throw new \DomainException(self::unableToReadEnv($cause));
+        }
+        $keyStream = Psr7\stream_for(file_get_contents($path));
 
-  /**
-   * Updates metadata with the authorization token
-   *
-   * @param array $metadata metadata hashmap
-   * @param string $authUri optional auth uri
-   * @param callable $httpHandler callback which delivers psr7 request
-   *
-   * @return array updated metadata hashmap
-   */
-  public function updateMetadata(
-    $metadata,
-    $authUri = null,
-    callable $httpHandler = null
-  ) {
-    $result = $this->fetchAuthToken($httpHandler);
-    if (!isset($result['access_token'])) {
-      return $metadata;
+        return static::makeCredentials($scope, $keyStream);
     }
-    $metadata_copy = $metadata;
-    $metadata_copy[self::AUTH_METADATA_KEY] = array('Bearer ' . $result['access_token']);
-    return $metadata_copy;
-  }
+
+    /**
+     * Create a credentials instance from a well known path.
+     *
+     * The well known path is OS dependent:
+     * - windows: %APPDATA%/gcloud/application_default_credentials.json
+     * - others: $HOME/.config/gcloud/application_default_credentials.json
+     *
+     * If the file does not exists, this returns null.
+     *
+     * @param string|array scope the scope of the access request, expressed
+     *   either as an Array or as a space-delimited String.
+     *
+     * @return a Credentials instance | null
+     */
+    public static function fromWellKnownFile($scope = null)
+    {
+        $rootEnv = self::isOnWindows() ? 'APPDATA' : 'HOME';
+        $path = [getenv($rootEnv)];
+        if (!self::isOnWindows()) {
+            $path[] = self::NON_WINDOWS_WELL_KNOWN_PATH_BASE;
+        }
+        $path[] = self::WELL_KNOWN_PATH;
+        $path = implode(DIRECTORY_SEPARATOR, $path);
+        if (!file_exists($path)) {
+            return;
+        }
+        $keyStream = Psr7\stream_for(file_get_contents($path));
+
+        return static::makeCredentials($scope, $keyStream);
+    }
+
+    /**
+     * Create a new Credentials instance.
+     *
+     * @param string|array scope the scope of the access request, expressed
+     *   either as an Array or as a space-delimited String.
+     * @param StreamInterface jsonKeyStream read it to get the JSON credentials.
+     */
+    public static function makeCredentials($scope, StreamInterface $jsonKeyStream)
+    {
+        $jsonKey = json_decode($jsonKeyStream->getContents(), true);
+        if (!array_key_exists('type', $jsonKey)) {
+            throw new \InvalidArgumentException(
+                'json key is missing the type field');
+        }
+
+        if ($jsonKey['type'] == 'service_account') {
+            return new ServiceAccountCredentials($scope, $jsonKey);
+        } elseif ($jsonKey['type'] == 'authorized_user') {
+            return new UserRefreshCredentials($scope, $jsonKey);
+        } else {
+            throw new \InvalidArgumentException(
+                'invalid value in the type field');
+        }
+    }
+
+    /**
+     * export a callback function which updates runtime metadata.
+     *
+     * @return an updateMetadata function
+     */
+    public function getUpdateMetadataFunc()
+    {
+        return array($this, 'updateMetadata');
+    }
+
+    /**
+     * Updates metadata with the authorization token.
+     *
+     * @param array $metadata metadata hashmap
+     * @param string $authUri optional auth uri
+     * @param callable $httpHandler callback which delivers psr7 request
+     *
+     * @return array updated metadata hashmap
+     */
+    public function updateMetadata(
+        $metadata,
+        $authUri = null,
+        callable $httpHandler = null
+    ) {
+        $result = $this->fetchAuthToken($httpHandler);
+        if (!isset($result['access_token'])) {
+            return $metadata;
+        }
+        $metadata_copy = $metadata;
+        $metadata_copy[self::AUTH_METADATA_KEY] = array('Bearer '.$result['access_token']);
+
+        return $metadata_copy;
+    }
 }

--- a/src/FetchAuthTokenInterface.php
+++ b/src/FetchAuthTokenInterface.php
@@ -22,34 +22,34 @@ namespace Google\Auth;
  */
 interface FetchAuthTokenInterface
 {
+    /**
+     * Fetches the auth tokens based on the current state.
+     *
+     * @param callable $httpHandler callback which delivers psr7 request
+     *
+     * @return array a hash of auth tokens
+     */
+    public function fetchAuthToken(callable $httpHandler = null);
 
- /**
-  * Fetches the auth tokens based on the current state.
-  *
-  * @param callable $httpHandler callback which delivers psr7 request
-  * @return array a hash of auth tokens
-  */
-  public function fetchAuthToken(callable $httpHandler = null);
+    /**
+     * Obtains a key that can used to cache the results of #fetchAuthToken.
+     *
+     * If the value is empty, the auth token is not cached.
+     *
+     * @return string a key that may be used to cache the auth token.
+     */
+    public function getCacheKey();
 
- /**
-  * Obtains a key that can used to cache the results of #fetchAuthToken.
-  *
-  * If the value is empty, the auth token is not cached.
-  *
-  * @return string a key that may be used to cache the auth token.
-  */
-  public function getCacheKey();
-
-  /**
-   * Returns an associative array with the token and
-   * expiration time.
-   *
-   * @return null|array {
-   *      The last received access token.
-   *
-   *      @type string $access_token The access token string.
-   *      @type int $expires_at The time the token expires as a UNIX timestamp.
-   * }
-   */
-  public function getLastReceivedToken();
+    /**
+     * Returns an associative array with the token and
+     * expiration time.
+     *
+     * @return null|array {
+     *      The last received access token.
+     *
+     * @var string $access_token The access token string.
+     * @var int $expires_at The time the token expires as a UNIX timestamp.
+     * }
+     */
+    public function getLastReceivedToken();
 }

--- a/src/HttpHandler/Guzzle5HttpHandler.php
+++ b/src/HttpHandler/Guzzle5HttpHandler.php
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 namespace Google\Auth\HttpHandler;
 
 use GuzzleHttp\ClientInterface;
@@ -24,45 +23,46 @@ use Psr\Http\Message\ResponseInterface;
 
 class Guzzle5HttpHandler
 {
-  /**
-   * @var ClientInterface
-   */
-  private $client;
+    /**
+     * @var ClientInterface
+     */
+    private $client;
 
-  /**
-   * @param ClientInterface $client
-   */
-  public function __construct(ClientInterface $client)
-  {
-    $this->client = $client;
-  }
+    /**
+     * @param ClientInterface $client
+     */
+    public function __construct(ClientInterface $client)
+    {
+        $this->client = $client;
+    }
 
-  /**
-   * Accepts a PSR-7 Request and an array of options and returns a PSR-7 response.
-   *
-   * @param RequestInterface $request
-   * @param array $options
-   * @return ResponseInterface
-   */
-  public function __invoke(RequestInterface $request, array $options = [])
-  {
-    $request = $this->client->createRequest(
-      $request->getMethod(),
-      $request->getUri(),
-      array_merge([
-        'headers' => $request->getHeaders(),
-        'body' => $request->getBody()
-      ], $options)
-    );
+    /**
+     * Accepts a PSR-7 Request and an array of options and returns a PSR-7 response.
+     *
+     * @param RequestInterface $request
+     * @param array $options
+     *
+     * @return ResponseInterface
+     */
+    public function __invoke(RequestInterface $request, array $options = [])
+    {
+        $request = $this->client->createRequest(
+            $request->getMethod(),
+            $request->getUri(),
+            array_merge([
+                'headers' => $request->getHeaders(),
+                'body' => $request->getBody(),
+            ], $options)
+        );
 
-    $response = $this->client->send($request);
+        $response = $this->client->send($request);
 
-    return new Response(
-      $response->getStatusCode(),
-      $response->getHeaders() ?: [],
-      $response->getBody(),
-      $response->getProtocolVersion(),
-      $response->getReasonPhrase()
-    );
-  }
+        return new Response(
+            $response->getStatusCode(),
+            $response->getHeaders() ?: [],
+            $response->getBody(),
+            $response->getProtocolVersion(),
+            $response->getReasonPhrase()
+        );
+    }
 }

--- a/src/HttpHandler/Guzzle6HttpHandler.php
+++ b/src/HttpHandler/Guzzle6HttpHandler.php
@@ -8,28 +8,29 @@ use Psr\Http\Message\ResponseInterface;
 
 class Guzzle6HttpHandler
 {
-  /**
-   * @var ClientInterface
-   */
-  private $client;
+    /**
+     * @var ClientInterface
+     */
+    private $client;
 
-  /**
-   * @param ClientInterface $client
-   */
-  public function __construct(ClientInterface $client)
-  {
-    $this->client = $client;
-  }
+    /**
+     * @param ClientInterface $client
+     */
+    public function __construct(ClientInterface $client)
+    {
+        $this->client = $client;
+    }
 
-  /**
-   * Accepts a PSR-7 request and an array of options and returns a PSR-7 response.
-   *
-   * @param RequestInterface $request
-   * @param array $options
-   * @return ResponseInterface
-   */
-  public function __invoke(RequestInterface $request, array $options = [])
-  {
-    return $this->client->send($request, $options);
-  }
+    /**
+     * Accepts a PSR-7 request and an array of options and returns a PSR-7 response.
+     *
+     * @param RequestInterface $request
+     * @param array $options
+     *
+     * @return ResponseInterface
+     */
+    public function __invoke(RequestInterface $request, array $options = [])
+    {
+        return $this->client->send($request, $options);
+    }
 }

--- a/src/HttpHandler/HttpHandlerFactory.php
+++ b/src/HttpHandler/HttpHandlerFactory.php
@@ -24,6 +24,8 @@ class HttpHandlerFactory
     /**
      * Builds out a default http handler for the installed version of guzzle.
      *
+     * @param ClientInterface $client
+     *
      * @return Guzzle5HttpHandler|Guzzle6HttpHandler
      *
      * @throws \Exception

--- a/src/HttpHandler/HttpHandlerFactory.php
+++ b/src/HttpHandler/HttpHandlerFactory.php
@@ -14,34 +14,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 namespace Google\Auth\HttpHandler;
 
-use Google\Auth\HttpHandler\Guzzle5HttpHandler;
-use Google\Auth\HttpHandler\Guzzle6HttpHandler;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 
 class HttpHandlerFactory
 {
-  /**
-   * Builds out a default http handler for the installed version of guzzle.
-   *
-   * @return Guzzle5HttpHandler|Guzzle6HttpHandler
-   * @throws \Exception
-   */
-  public static function build(ClientInterface $client = null)
-  {
-    $version = ClientInterface::VERSION;
-    $client = $client ?: new Client();
+    /**
+     * Builds out a default http handler for the installed version of guzzle.
+     *
+     * @return Guzzle5HttpHandler|Guzzle6HttpHandler
+     *
+     * @throws \Exception
+     */
+    public static function build(ClientInterface $client = null)
+    {
+        $version = ClientInterface::VERSION;
+        $client = $client ?: new Client();
 
-    switch ($version[0]) {
-      case '5':
-          return new Guzzle5HttpHandler($client);
-      case '6':
-          return new Guzzle6HttpHandler($client);
-      default:
-          throw new \Exception('Version not supported');
+        switch ($version[0]) {
+            case '5':
+                return new Guzzle5HttpHandler($client);
+            case '6':
+                return new Guzzle6HttpHandler($client);
+            default:
+                throw new \Exception('Version not supported');
+        }
     }
-  }
 }

--- a/src/Middleware/AuthTokenMiddleware.php
+++ b/src/Middleware/AuthTokenMiddleware.php
@@ -39,16 +39,24 @@ class AuthTokenMiddleware
 
     const DEFAULT_CACHE_LIFETIME = 1500;
 
-    /** @var An implementation of CacheInterface */
+    /**
+     * @var CacheInterface
+     */
     private $cache;
 
-    /** @var callback */
+    /**
+     * @var callback
+     */
     private $httpHandler;
 
-    /** @var An implementation of FetchAuthTokenInterface */
+    /**
+     * @var FetchAuthTokenInterface
+     */
     private $fetcher;
 
-    /** @var cache configuration */
+    /**
+     * @var array configuration
+     */
     private $cacheConfig;
 
     /**
@@ -101,6 +109,10 @@ class AuthTokenMiddleware
      *   ]);
      *
      *   $res = $client->get('myproject/taskqueues/myqueue');
+     *
+     * @param callable $handler
+     *
+     * @return \Closure
      */
     public function __invoke(callable $handler)
     {

--- a/src/Middleware/ScopedAccessTokenMiddleware.php
+++ b/src/Middleware/ScopedAccessTokenMiddleware.php
@@ -40,17 +40,35 @@ class ScopedAccessTokenMiddleware
 
     const DEFAULT_CACHE_LIFETIME = 1500;
 
-    /** @var An implementation of CacheInterface */
+    /**
+     * @var CacheInterface
+     */
     private $cache;
 
-    /** @var callback */
+    /**
+     * @var callback
+     */
     private $httpHandler;
 
-    /** @var An implementation of FetchAuthTokenInterface */
+    /**
+     * @var FetchAuthTokenInterface
+     */
     private $fetcher;
 
-    /** @var cache configuration */
+    /**
+     * @var array configuration
+     */
     private $cacheConfig;
+
+    /**
+     * @var callable
+     */
+    private $tokenFunc;
+
+    /**
+     * @var array|string
+     */
+    private $scopes;
 
     /**
      * Creates a new ScopedAccessTokenMiddleware.
@@ -110,6 +128,10 @@ class ScopedAccessTokenMiddleware
      *   ]);
      *
      *   $res = $client->get('myproject/taskqueues/myqueue');
+     *
+     * @param callable $handler
+     *
+     * @return \Closure
      */
     public function __invoke(callable $handler)
     {

--- a/src/Middleware/ScopedAccessTokenMiddleware.php
+++ b/src/Middleware/ScopedAccessTokenMiddleware.php
@@ -36,125 +36,128 @@ use Psr\Http\Message\RequestInterface;
  */
 class ScopedAccessTokenMiddleware
 {
-  use CacheTrait;
+    use CacheTrait;
 
-  const DEFAULT_CACHE_LIFETIME = 1500;
+    const DEFAULT_CACHE_LIFETIME = 1500;
 
-  /** @var An implementation of CacheInterface */
-  private $cache;
+    /** @var An implementation of CacheInterface */
+    private $cache;
 
-  /** @var callback */
-  private $httpHandler;
+    /** @var callback */
+    private $httpHandler;
 
-  /** @var An implementation of FetchAuthTokenInterface */
-  private $fetcher;
+    /** @var An implementation of FetchAuthTokenInterface */
+    private $fetcher;
 
-  /** @var cache configuration */
-  private $cacheConfig;
+    /** @var cache configuration */
+    private $cacheConfig;
 
-  /**
-   * Creates a new ScopedAccessTokenMiddleware.
-   *
-   * @param callable $tokenFunc a token generator function
-   * @param array|string $scopes the token authentication scopes
-   * @param array $cacheConfig configuration for the cache when it's present
-   * @param CacheInterface $cache an implementation of CacheInterface
-   */
-  public function __construct(
-    callable $tokenFunc,
-    $scopes,
-    array $cacheConfig = null,
-    CacheInterface $cache = null
-  ) {
-    $this->tokenFunc = $tokenFunc;
-    if (!(is_string($scopes) || is_array($scopes))) {
-      throw new \InvalidArgumentException(
-          'wants scope should be string or array');
-    }
-    $this->scopes = $scopes;
+    /**
+     * Creates a new ScopedAccessTokenMiddleware.
+     *
+     * @param callable $tokenFunc a token generator function
+     * @param array|string $scopes the token authentication scopes
+     * @param array $cacheConfig configuration for the cache when it's present
+     * @param CacheInterface $cache an implementation of CacheInterface
+     */
+    public function __construct(
+        callable $tokenFunc,
+        $scopes,
+        array $cacheConfig = null,
+        CacheInterface $cache = null
+    ) {
+        $this->tokenFunc = $tokenFunc;
+        if (!(is_string($scopes) || is_array($scopes))) {
+            throw new \InvalidArgumentException(
+                'wants scope should be string or array');
+        }
+        $this->scopes = $scopes;
 
-    if (!is_null($cache)) {
-      $this->cache = $cache;
-      $this->cacheConfig = array_merge([
-        'lifetime' => self::DEFAULT_CACHE_LIFETIME,
-        'prefix'   => ''
-      ], $cacheConfig);
-    }
-  }
-
-  /**
-   * Updates the request with an Authorization header when auth is 'scoped'.
-   *
-   *   E.g this could be used to authenticate using the AppEngine
-   *   AppIdentityService.
-   *
-   *   use google\appengine\api\app_identity\AppIdentityService;
-   *   use Google\Auth\Middleware\ScopedAccessTokenMiddleware;
-   *   use GuzzleHttp\Client;
-   *   use GuzzleHttp\HandlerStack;
-   *
-   *   $scope = 'https://www.googleapis.com/auth/taskqueue'
-   *   $middleware = new ScopedAccessTokenMiddleware(
-   *       'AppIdentityService::getAccessToken',
-   *       $scope,
-   *       [ 'prefix' => 'Google\Auth\ScopedAccessToken::' ],
-   *       $cache = new Memcache()
-   *   );
-   *   $stack = HandlerStack::create();
-   *   $stack->push($middleware);
-   *
-   *   $client = new Client([
-   *       'handler' => $stack,
-   *       'base_url' => 'https://www.googleapis.com/taskqueue/v1beta2/projects/',
-   *       'auth' => 'google_auth' // authorize all requests
-   *   ]);
-   *
-   *   $res = $client->get('myproject/taskqueues/myqueue');
-   */
-  public function __invoke(callable $handler)
-  {
-    return function (RequestInterface $request, array $options) use ($handler) {
-      // Requests using "auth"="scoped" will be authorized.
-      if (!isset($options['auth']) || $options['auth'] !== 'scoped') {
-        return $handler($request, $options);
-      }
-
-      $request = $request->withHeader('Authorization', 'Bearer ' . $this->fetchToken());
-      return $handler($request, $options);
-    };
-  }
-
-  /**
-   * @return string
-   */
-  private function getCacheKey()
-  {
-    $key = null;
-
-    if (is_string($this->scopes)) {
-      $key .= $this->scopes;
-    } else if (is_array($this->scopes)) {
-      $key .= implode(":", $this->scopes);
-    }
-    return $key;
-  }
-
-  /**
-   * Determine if token is available in the cache, if not call tokenFunc to
-   * fetch it.
-   *
-   * @return string
-   */
-  private function fetchToken()
-  {
-    $cached = $this->getCachedValue();
-
-    if (!empty($cached)) {
-      return $cached;
+        if (!is_null($cache)) {
+            $this->cache = $cache;
+            $this->cacheConfig = array_merge([
+                'lifetime' => self::DEFAULT_CACHE_LIFETIME,
+                'prefix' => '',
+            ], $cacheConfig);
+        }
     }
 
-    $token = call_user_func($this->tokenFunc, $this->scopes);
-    $this->setCachedValue($token);
-    return $token;
-  }
+    /**
+     * Updates the request with an Authorization header when auth is 'scoped'.
+     *
+     *   E.g this could be used to authenticate using the AppEngine
+     *   AppIdentityService.
+     *
+     *   use google\appengine\api\app_identity\AppIdentityService;
+     *   use Google\Auth\Middleware\ScopedAccessTokenMiddleware;
+     *   use GuzzleHttp\Client;
+     *   use GuzzleHttp\HandlerStack;
+     *
+     *   $scope = 'https://www.googleapis.com/auth/taskqueue'
+     *   $middleware = new ScopedAccessTokenMiddleware(
+     *       'AppIdentityService::getAccessToken',
+     *       $scope,
+     *       [ 'prefix' => 'Google\Auth\ScopedAccessToken::' ],
+     *       $cache = new Memcache()
+     *   );
+     *   $stack = HandlerStack::create();
+     *   $stack->push($middleware);
+     *
+     *   $client = new Client([
+     *       'handler' => $stack,
+     *       'base_url' => 'https://www.googleapis.com/taskqueue/v1beta2/projects/',
+     *       'auth' => 'google_auth' // authorize all requests
+     *   ]);
+     *
+     *   $res = $client->get('myproject/taskqueues/myqueue');
+     */
+    public function __invoke(callable $handler)
+    {
+        return function (RequestInterface $request, array $options) use ($handler) {
+            // Requests using "auth"="scoped" will be authorized.
+            if (!isset($options['auth']) || $options['auth'] !== 'scoped') {
+                return $handler($request, $options);
+            }
+
+            $request = $request->withHeader('Authorization', 'Bearer '.$this->fetchToken());
+
+            return $handler($request, $options);
+        };
+    }
+
+    /**
+     * @return string
+     */
+    private function getCacheKey()
+    {
+        $key = null;
+
+        if (is_string($this->scopes)) {
+            $key .= $this->scopes;
+        } elseif (is_array($this->scopes)) {
+            $key .= implode(':', $this->scopes);
+        }
+
+        return $key;
+    }
+
+    /**
+     * Determine if token is available in the cache, if not call tokenFunc to
+     * fetch it.
+     *
+     * @return string
+     */
+    private function fetchToken()
+    {
+        $cached = $this->getCachedValue();
+
+        if (!empty($cached)) {
+            return $cached;
+        }
+
+        $token = call_user_func($this->tokenFunc, $this->scopes);
+        $this->setCachedValue($token);
+
+        return $token;
+    }
 }

--- a/src/Middleware/SimpleMiddleware.php
+++ b/src/Middleware/SimpleMiddleware.php
@@ -28,7 +28,9 @@ use Psr\Http\Message\RequestInterface;
  */
 class SimpleMiddleware
 {
-    /** @var configuration */
+    /**
+     * @var array
+     */
     private $config;
 
     /**
@@ -67,6 +69,10 @@ class SimpleMiddleware
      *   ]);
      *
      *   $res = $client->get('drive/v2/rest');
+     *
+     * @param callable $handler
+     *
+     * @return \Closure
      */
     public function __invoke(callable $handler)
     {

--- a/src/Middleware/SimpleMiddleware.php
+++ b/src/Middleware/SimpleMiddleware.php
@@ -28,59 +28,60 @@ use Psr\Http\Message\RequestInterface;
  */
 class SimpleMiddleware
 {
-  /** @var configuration */
-  private $config;
+    /** @var configuration */
+    private $config;
 
-  /**
-   * Create a new Simple plugin.
-   *
-   * The configuration array expects one option
-   * - key: required, otherwise InvalidArgumentException is thrown
-   *
-   * @param array $config Configuration array
-   */
-  public function __construct(array $config)
-  {
-    if (!isset($config['key'])) {
-      throw new \InvalidArgumentException('requires a key to have been set');
+    /**
+     * Create a new Simple plugin.
+     *
+     * The configuration array expects one option
+     * - key: required, otherwise InvalidArgumentException is thrown
+     *
+     * @param array $config Configuration array
+     */
+    public function __construct(array $config)
+    {
+        if (!isset($config['key'])) {
+            throw new \InvalidArgumentException('requires a key to have been set');
+        }
+
+        $this->config = array_merge(['key' => null], $config);
     }
 
-    $this->config = array_merge(['key' => null], $config);
-  }
+    /**
+     * Updates the request query with the developer key if auth is set to simple.
+     *
+     *   use Google\Auth\Middleware\SimpleMiddleware;
+     *   use GuzzleHttp\Client;
+     *   use GuzzleHttp\HandlerStack;
+     *
+     *   $my_key = 'is not the same as yours';
+     *   $middleware = new SimpleMiddleware(['key' => $my_key]);
+     *   $stack = HandlerStack::create();
+     *   $stack->push($middleware);
+     *
+     *   $client = new Client([
+     *       'handler' => $stack,
+     *       'base_uri' => 'https://www.googleapis.com/discovery/v1/',
+     *       'auth' => 'simple'
+     *   ]);
+     *
+     *   $res = $client->get('drive/v2/rest');
+     */
+    public function __invoke(callable $handler)
+    {
+        return function (RequestInterface $request, array $options) use ($handler) {
+            // Requests using "auth"="scoped" will be authorized.
+            if (!isset($options['auth']) || $options['auth'] !== 'simple') {
+                return $handler($request, $options);
+            }
 
-  /**
-   * Updates the request query with the developer key if auth is set to simple
-   *
-   *   use Google\Auth\Middleware\SimpleMiddleware;
-   *   use GuzzleHttp\Client;
-   *   use GuzzleHttp\HandlerStack;
-   *
-   *   $my_key = 'is not the same as yours';
-   *   $middleware = new SimpleMiddleware(['key' => $my_key]);
-   *   $stack = HandlerStack::create();
-   *   $stack->push($middleware);
-   *
-   *   $client = new Client([
-   *       'handler' => $stack,
-   *       'base_uri' => 'https://www.googleapis.com/discovery/v1/',
-   *       'auth' => 'simple'
-   *   ]);
-   *
-   *   $res = $client->get('drive/v2/rest');
-   */
-  public function __invoke(callable $handler)
-  {
-    return function (RequestInterface $request, array $options) use ($handler) {
-      // Requests using "auth"="scoped" will be authorized.
-      if (!isset($options['auth']) || $options['auth'] !== 'simple') {
-        return $handler($request, $options);
-      }
+            $query = Psr7\parse_query($request->getUri()->getQuery());
+            $params = array_merge($query, $this->config);
+            $uri = $request->getUri()->withQuery(Psr7\build_query($params));
+            $request = $request->withUri($uri);
 
-      $query = Psr7\parse_query($request->getUri()->getQuery());
-      $params = array_merge($query, $this->config);
-      $uri = $request->getUri()->withQuery(Psr7\build_query($params));
-      $request = $request->withUri($uri);
-      return $handler($request, $options);
-    };
-  }
+            return $handler($request, $options);
+        };
+    }
 }

--- a/src/OAuth2.php
+++ b/src/OAuth2.php
@@ -34,1232 +34,1255 @@ use Psr\Http\Message\UriInterface;
  */
 class OAuth2 implements FetchAuthTokenInterface
 {
-  const DEFAULT_EXPIRY_SECONDS = 3600; // 1 hour
-  const DEFAULT_SKEW_SECONDS = 60; // 1 minute
-  const JWT_URN = 'urn:ietf:params:oauth:grant-type:jwt-bearer';
+    const DEFAULT_EXPIRY_SECONDS = 3600; // 1 hour
+    const DEFAULT_SKEW_SECONDS = 60; // 1 minute
+    const JWT_URN = 'urn:ietf:params:oauth:grant-type:jwt-bearer';
 
-  /**
-   * TODO: determine known methods from the keys of JWT::methods
-   */
-  public static $knownSigningAlgorithms = array('HS256', 'HS512', 'HS384',
-                                                'RS256');
-
-  /**
-   * The well known grant types.
-   *
-   * @var array
-   */
-  public static $knownGrantTypes = array('authorization_code',
-                                         'refresh_token',
-                                         'password',
-                                         'client_credentials');
-
-  /**
-   * - authorizationUri
-   *   The authorization server's HTTP endpoint capable of
-   *   authenticating the end-user and obtaining authorization.
-   *
-   * @var UriInterface
-   */
-  private $authorizationUri;
-
-  /**
-   * - tokenCredentialUri
-   *   The authorization server's HTTP endpoint capable of issuing
-   *   tokens and refreshing expired tokens.
-   *
-   * @var UriInterface
-   */
-  private $tokenCredentialUri;
-
-  /**
-   * The redirection URI used in the initial request.
-   *
-   * @var string
-   */
-  private $redirectUri;
-
-  /**
-   * A unique identifier issued to the client to identify itself to the
-   * authorization server.
-   *
-   * @var string
-   */
-  private $clientId;
-
-  /**
-   * A shared symmetric secret issued by the authorization server, which is
-   * used to authenticate the client.
-   *
-   * @var string
-   */
-  private $clientSecret;
-
-  /**
-   * The resource owner's username.
-   *
-   * @var string
-   */
-  private $username;
-
-  /**
-   * The resource owner's password.
-   *
-   * @var string
-   */
-  private $password;
-
-  /**
-   * The scope of the access request, expressed either as an Array or as a
-   * space-delimited string.
-   *
-   * @var string
-   */
-  private $scope;
-
-  /**
-   * An arbitrary string designed to allow the client to maintain state.
-   *
-   * @var string
-   */
-  private $state;
-
-  /**
-   * The authorization code issued to this client.
-   *
-   * Only used by the authorization code access grant type.
-   *
-   * @var string
-   */
-  private $code;
-
-  /**
-   * The issuer ID when using assertion profile.
-   *
-   * @var string
-   */
-  private $issuer;
-
-  /**
-   * The target audience for assertions.
-   *
-   * @var string
-   */
-  private $audience;
-
-  /**
-   * The target sub when issuing assertions.
-   *
-   * @var string
-   */
-  private $sub;
-
-  /**
-   * The number of seconds assertions are valid for.
-   *
-   * @var int
-   */
-  private $expiry;
-
-  /**
-   * The signing key when using assertion profile.
-   *
-   * @var string
-   */
-  private $signingKey;
-
-  /**
-   * The signing algorithm when using an assertion profile.
-   *
-   * @var string
-   */
-  private $signingAlgorithm;
-
-  /**
-   * The refresh token associated with the access token to be refreshed.
-   *
-   * @var string
-   */
-  private $refreshToken;
-
-  /**
-   * The current access token.
-   *
-   * @var string
-   */
-  private $accessToken;
-
-  /**
-   * The current ID token.
-   *
-   * @var string
-   */
-  private $idToken;
-
-  /**
-   * The lifetime in seconds of the current access token.
-   *
-   * @var int
-   */
-  private $expiresIn;
-
-  /**
-   * The expiration time of the access token as a number of seconds since the
-   * unix epoch.
-   *
-   * @var int
-   */
-  private $expiresAt;
-
-  /**
-   * The issue time of the access token as a number of seconds since the unix
-   * epoch.
-   *
-   * @var int
-   */
-  private $issuedAt;
-
-  /**
-   * The current grant type.
-   *
-   * @var string
-   */
-  private $grantType;
-
-  /**
-   * When using an extension grant type, this is the set of parameters used by
-   * that extension.
-   */
-  private $extensionParams;
-
-  /**
-   * Create a new OAuthCredentials.
-   *
-   * The configuration array accepts various options
-   *
-   * - authorizationUri
-   *   The authorization server's HTTP endpoint capable of
-   *   authenticating the end-user and obtaining authorization.
-   *
-   * - tokenCredentialUri
-   *   The authorization server's HTTP endpoint capable of issuing
-   *   tokens and refreshing expired tokens.
-   *
-   * - clientId
-   *   A unique identifier issued to the client to identify itself to the
-   *   authorization server.
-   *
-   * - clientSecret
-   *   A shared symmetric secret issued by the authorization server,
-   *   which is used to authenticate the client.
-   *
-   * - scope
-   *   The scope of the access request, expressed either as an Array
-   *   or as a space-delimited String.
-   *
-   * - state
-   *   An arbitrary string designed to allow the client to maintain state.
-   *
-   * - redirectUri
-   *   The redirection URI used in the initial request.
-   *
-   * - username
-   *   The resource owner's username.
-   *
-   * - password
-   *   The resource owner's password.
-   *
-   * - issuer
-   *   Issuer ID when using assertion profile
-   *
-   * - audience
-   *   Target audience for assertions
-   *
-   * - expiry
-   *   Number of seconds assertions are valid for
-   *
-   * - signingKey
-   *   Signing key when using assertion profile
-   *
-   * - refreshToken
-   *   The refresh token associated with the access token
-   *   to be refreshed.
-   *
-   * - accessToken
-   *   The current access token for this client.
-   *
-   * - idToken
-   *   The current ID token for this client.
-   *
-   * - extensionParams
-   *   When using an extension grant type, this is the set of parameters used
-   *   by that extension.
-   *
-   * @param array $config Configuration array
-   */
-  public function __construct(array $config)
-  {
-    $opts = array_merge([
-      'expiry' => self::DEFAULT_EXPIRY_SECONDS,
-      'extensionParams' => [],
-      'authorizationUri' => null,
-      'redirectUri' => null,
-      'tokenCredentialUri' => null,
-      'state' => null,
-      'username' => null,
-      'password' => null,
-      'clientId' => null,
-      'clientSecret' => null,
-      'issuer' => null,
-      'sub' => null,
-      'audience' => null,
-      'signingKey' => null,
-      'signingAlgorithm' => null,
-      'scope' => null
-    ], $config);
-
-    $this->setAuthorizationUri($opts['authorizationUri']);
-    $this->setRedirectUri($opts['redirectUri']);
-    $this->setTokenCredentialUri($opts['tokenCredentialUri']);
-    $this->setState($opts['state']);
-    $this->setUsername($opts['username']);
-    $this->setPassword($opts['password']);
-    $this->setClientId($opts['clientId']);
-    $this->setClientSecret($opts['clientSecret']);
-    $this->setIssuer($opts['issuer']);
-    $this->setSub($opts['sub']);
-    $this->setExpiry($opts['expiry']);
-    $this->setAudience($opts['audience']);
-    $this->setSigningKey($opts['signingKey']);
-    $this->setSigningAlgorithm($opts['signingAlgorithm']);
-    $this->setScope($opts['scope']);
-    $this->setExtensionParams($opts['extensionParams']);
-    $this->updateToken($opts);
-  }
-
-  /**
-   * Verifies the idToken if present.
-   *
-   * - if none is present, return null
-   * - if present, but invalid, raises DomainException.
-   * - otherwise returns the payload in the idtoken as a PHP object.
-   *
-   * if $publicKey is null, the key is decoded without being verified.
-   *
-   * @param string $publicKey The public key to use to authenticate the token
-   * @param array $allowed_algs List of supported verification algorithms
-   *
-   * @return null|object
-   */
-  public function verifyIdToken($publicKey = null, $allowed_algs = array())
-  {
-    $idToken = $this->getIdToken();
-    if (is_null($idToken)) {
-      return null;
-    }
-
-    $resp = $this->jwtDecode($idToken, $publicKey, $allowed_algs);
-    if (!property_exists($resp, 'aud')) {
-      throw new \DomainException('No audience found the id token');
-    }
-    if ($resp->aud != $this->getAudience()) {
-      throw new \DomainException('Wrong audience present in the id token');
-    }
-    return $resp;
-  }
-
-  /**
-   * Obtains the encoded jwt from the instance data.
-   *
-   * @param array $config array optional configuration parameters
-   *
-   * @return string
-   */
-  public function toJwt(array $config = [])
-  {
-    if (is_null($this->getSigningKey())) {
-      throw new \DomainException('No signing key available');
-    }
-    if (is_null($this->getSigningAlgorithm())) {
-      throw new \DomainException('No signing algorithm specified');
-    }
-    $now = time();
-
-    $opts = array_merge([
-      'skew' => self::DEFAULT_SKEW_SECONDS
-    ], $config);
-
-    $assertion = [
-        'iss' => $this->getIssuer(),
-        'aud' => $this->getAudience(),
-        'exp' => ($now + $this->getExpiry()),
-        'iat' => ($now - $opts['skew'])
-    ];
-    foreach ($assertion as $k => $v) {
-      if (is_null($v)) {
-        throw new \DomainException($k . ' should not be null');
-      }
-    }
-    if (!(is_null($this->getScope()))) {
-      $assertion['scope'] = $this->getScope();
-    }
-    if (!(is_null($this->getSub()))) {
-      $assertion['sub'] = $this->getSub();
-    }
-    return $this->jwtEncode($assertion, $this->getSigningKey(),
-                       $this->getSigningAlgorithm());
-  }
-
- /**
-  * Generates a request for token credentials.
-  *
-  * @return RequestInterface the authorization Url.
-  */
-  public function generateCredentialsRequest()
-  {
-    $uri = $this->getTokenCredentialUri();
-    if (is_null($uri)) {
-      throw new \DomainException('No token credential URI was set.');
-    }
-
-    $grantType = $this->getGrantType();
-    $params = array('grant_type' => $grantType);
-    switch($grantType) {
-      case 'authorization_code':
-        $params['code'] = $this->getCode();
-        $params['redirect_uri'] = $this->getRedirectUri();
-        $this->addClientCredentials($params);
-        break;
-      case 'password':
-        $params['username'] = $this->getUsername();
-        $params['password'] = $this->getPassword();
-        $this->addClientCredentials($params);
-        break;
-      case 'refresh_token':
-        $params['refresh_token'] = $this->getRefreshToken();
-        $this->addClientCredentials($params);
-        break;
-      case self::JWT_URN:
-        $params['assertion'] = $this->toJwt();
-        break;
-      default:
-        if (!is_null($this->getRedirectUri())) {
-          # Grant type was supposed to be 'authorization_code', as there
-          # is a redirect URI.
-          throw new \DomainException('Missing authorization code');
-        }
-        unset($params['grant_type']);
-        if (!is_null($grantType)) {
-          $params['grant_type'] = $grantType;
-        }
-        $params = array_merge($params, $this->getExtensionParams());
-    }
-
-    $headers = [
-      'Cache-Control' => 'no-store',
-      'Content-Type' => 'application/x-www-form-urlencoded'
-    ];
-
-    return new Request(
-      'POST',
-      $uri,
-      $headers,
-      Psr7\build_query($params)
-    );
-  }
-
- /**
-  * Fetches the auth tokens based on the current state.
-  *
-  * @param callable $httpHandler callback which delivers psr7 request
-  * @return array the response
-  */
-  public function fetchAuthToken(callable $httpHandler = null)
-  {
-    if (is_null($httpHandler)) {
-      $httpHandler = HttpHandlerFactory::build();
-    }
-
-    $response = $httpHandler($this->generateCredentialsRequest());
-    $credentials = $this->parseTokenResponse($response);
-    $this->updateToken($credentials);
-    return $credentials;
-  }
-
- /**
-  * Obtains a key that can used to cache the results of #fetchAuthToken.
-  *
-  * The key is derived from the scopes.
-  *
-  * @return string a key that may be used to cache the auth token.
-  */
-  public function getCacheKey() {
-    if (is_string($this->scope)) {
-      return $this->scope;
-    } else if (is_array($this->scope)) {
-      return implode(":", $this->scope);
-    }
-
-    // If scope has not set, return null to indicate no caching.
-    return null;
-  }
-
-  /**
-   * Parses the fetched tokens.
-   *
-   * @param ResponseInterface $resp the response.
-   *
-   * @return array the tokens parsed from the response body.
-   * @throws \Exception
-   */
-  public function parseTokenResponse(ResponseInterface $resp)
-  {
-    $body = (string) $resp->getBody();
-    if ($resp->hasHeader('Content-Type') &&
-        $resp->getHeaderLine('Content-Type') == 'application/x-www-form-urlencoded') {
-      $res = array();
-      parse_str($body, $res);
-      return $res;
-    } else {
-      // Assume it's JSON; if it's not throw an exception
-      if (null === $res = json_decode($body, true)) {
-        throw new \Exception('Invalid JSON response');
-      }
-
-      return $res;
-    }
-  }
-
- /**
-  * Updates an OAuth 2.0 client.
-  *
-  * @example
-  *   client.updateToken([
-  *     'refresh_token' => 'n4E9O119d',
-  *     'access_token' => 'FJQbwq9',
-  *     'expires_in' => 3600
-  *   ])
-  *
-  * @param array $config
-  *  The configuration parameters related to the token.
-  *
-  *  - refresh_token
-  *    The refresh token associated with the access token
-  *    to be refreshed.
-  *
-  *  - access_token
-  *    The current access token for this client.
-  *
-  *  - id_token
-  *    The current ID token for this client.
-  *
-  *  - expires_in
-  *    The time in seconds until access token expiration.
-  *
-  *  - expires_at
-  *    The time as an integer number of seconds since the Epoch
-  *
-  *  - issued_at
-  *    The timestamp that the token was issued at.
-  */
-  public function updateToken(array $config)
-  {
-    $opts = array_merge([
-      'extensionParams' => [],
-      'refresh_token' => null,
-      'access_token' => null,
-      'id_token' => null,
-      'expires' => null,
-      'expires_in' => null,
-      'expires_at' => null,
-      'issued_at' => null
-    ], $config);
-
-    $this->setExpiresAt($opts['expires']);
-    $this->setExpiresAt($opts['expires_at']);
-    $this->setExpiresIn($opts['expires_in']);
-    // By default, the token is issued at `Time.now` when `expiresIn` is set,
-    // but this can be used to supply a more precise time.
-    if (!is_null($opts['issued_at'])) {
-      $this->setIssuedAt($opts['issued_at']);
-    }
-
-    $this->setAccessToken($opts['access_token']);
-    $this->setIdToken($opts['id_token']);
-    $this->setRefreshToken($opts['refresh_token']);
-  }
-
-  /**
-   * Builds the authorization Uri that the user should be redirected to.
-   *
-   * @param array $config configuration options that customize the return url
-   * @return UriInterface the authorization Url.
-   * @throws InvalidArgumentException
-   */
-  public function buildFullAuthorizationUri(array $config = [])
-  {
-    if (is_null($this->getAuthorizationUri())) {
-      throw new InvalidArgumentException(
-          'requires an authorizationUri to have been set');
-    }
-
-    $params = array_merge([
-        'response_type' => 'code',
-        'access_type' => 'offline',
-        'client_id' => $this->clientId,
-        'redirect_uri' => $this->redirectUri,
-        'state' => $this->state,
-        'scope' => $this->getScope(),
-    ], $config);
-
-    // Validate the auth_params
-    if (is_null($params['client_id'])) {
-      throw new InvalidArgumentException(
-          'missing the required client identifier');
-    }
-    if (is_null($params['redirect_uri'])) {
-      throw new InvalidArgumentException('missing the required redirect URI');
-    }
-    if (!empty($params['prompt']) && !empty($params['approval_prompt'])) {
-      throw new InvalidArgumentException(
-          'prompt and approval_prompt are mutually exclusive');
-    }
-
-    // Construct the uri object; return it if it is valid.
-    $result = clone $this->authorizationUri;
-    $existingParams = Psr7\parse_query($result->getQuery());
-
-    $result = $result->withQuery(
-      Psr7\build_query(array_merge($existingParams, $params))
+    /**
+     * TODO: determine known methods from the keys of JWT::methods.
+     */
+    public static $knownSigningAlgorithms = array(
+        'HS256',
+        'HS512',
+        'HS384',
+        'RS256',
     );
 
-    if ($result->getScheme() != 'https') {
-      throw new InvalidArgumentException(
-          'Authorization endpoint must be protected by TLS');
+    /**
+     * The well known grant types.
+     *
+     * @var array
+     */
+    public static $knownGrantTypes = array(
+        'authorization_code',
+        'refresh_token',
+        'password',
+        'client_credentials',
+    );
+
+    /**
+     * - authorizationUri
+     *   The authorization server's HTTP endpoint capable of
+     *   authenticating the end-user and obtaining authorization.
+     *
+     * @var UriInterface
+     */
+    private $authorizationUri;
+
+    /**
+     * - tokenCredentialUri
+     *   The authorization server's HTTP endpoint capable of issuing
+     *   tokens and refreshing expired tokens.
+     *
+     * @var UriInterface
+     */
+    private $tokenCredentialUri;
+
+    /**
+     * The redirection URI used in the initial request.
+     *
+     * @var string
+     */
+    private $redirectUri;
+
+    /**
+     * A unique identifier issued to the client to identify itself to the
+     * authorization server.
+     *
+     * @var string
+     */
+    private $clientId;
+
+    /**
+     * A shared symmetric secret issued by the authorization server, which is
+     * used to authenticate the client.
+     *
+     * @var string
+     */
+    private $clientSecret;
+
+    /**
+     * The resource owner's username.
+     *
+     * @var string
+     */
+    private $username;
+
+    /**
+     * The resource owner's password.
+     *
+     * @var string
+     */
+    private $password;
+
+    /**
+     * The scope of the access request, expressed either as an Array or as a
+     * space-delimited string.
+     *
+     * @var string
+     */
+    private $scope;
+
+    /**
+     * An arbitrary string designed to allow the client to maintain state.
+     *
+     * @var string
+     */
+    private $state;
+
+    /**
+     * The authorization code issued to this client.
+     *
+     * Only used by the authorization code access grant type.
+     *
+     * @var string
+     */
+    private $code;
+
+    /**
+     * The issuer ID when using assertion profile.
+     *
+     * @var string
+     */
+    private $issuer;
+
+    /**
+     * The target audience for assertions.
+     *
+     * @var string
+     */
+    private $audience;
+
+    /**
+     * The target sub when issuing assertions.
+     *
+     * @var string
+     */
+    private $sub;
+
+    /**
+     * The number of seconds assertions are valid for.
+     *
+     * @var int
+     */
+    private $expiry;
+
+    /**
+     * The signing key when using assertion profile.
+     *
+     * @var string
+     */
+    private $signingKey;
+
+    /**
+     * The signing algorithm when using an assertion profile.
+     *
+     * @var string
+     */
+    private $signingAlgorithm;
+
+    /**
+     * The refresh token associated with the access token to be refreshed.
+     *
+     * @var string
+     */
+    private $refreshToken;
+
+    /**
+     * The current access token.
+     *
+     * @var string
+     */
+    private $accessToken;
+
+    /**
+     * The current ID token.
+     *
+     * @var string
+     */
+    private $idToken;
+
+    /**
+     * The lifetime in seconds of the current access token.
+     *
+     * @var int
+     */
+    private $expiresIn;
+
+    /**
+     * The expiration time of the access token as a number of seconds since the
+     * unix epoch.
+     *
+     * @var int
+     */
+    private $expiresAt;
+
+    /**
+     * The issue time of the access token as a number of seconds since the unix
+     * epoch.
+     *
+     * @var int
+     */
+    private $issuedAt;
+
+    /**
+     * The current grant type.
+     *
+     * @var string
+     */
+    private $grantType;
+
+    /**
+     * When using an extension grant type, this is the set of parameters used by
+     * that extension.
+     */
+    private $extensionParams;
+
+    /**
+     * Create a new OAuthCredentials.
+     *
+     * The configuration array accepts various options
+     *
+     * - authorizationUri
+     *   The authorization server's HTTP endpoint capable of
+     *   authenticating the end-user and obtaining authorization.
+     *
+     * - tokenCredentialUri
+     *   The authorization server's HTTP endpoint capable of issuing
+     *   tokens and refreshing expired tokens.
+     *
+     * - clientId
+     *   A unique identifier issued to the client to identify itself to the
+     *   authorization server.
+     *
+     * - clientSecret
+     *   A shared symmetric secret issued by the authorization server,
+     *   which is used to authenticate the client.
+     *
+     * - scope
+     *   The scope of the access request, expressed either as an Array
+     *   or as a space-delimited String.
+     *
+     * - state
+     *   An arbitrary string designed to allow the client to maintain state.
+     *
+     * - redirectUri
+     *   The redirection URI used in the initial request.
+     *
+     * - username
+     *   The resource owner's username.
+     *
+     * - password
+     *   The resource owner's password.
+     *
+     * - issuer
+     *   Issuer ID when using assertion profile
+     *
+     * - audience
+     *   Target audience for assertions
+     *
+     * - expiry
+     *   Number of seconds assertions are valid for
+     *
+     * - signingKey
+     *   Signing key when using assertion profile
+     *
+     * - refreshToken
+     *   The refresh token associated with the access token
+     *   to be refreshed.
+     *
+     * - accessToken
+     *   The current access token for this client.
+     *
+     * - idToken
+     *   The current ID token for this client.
+     *
+     * - extensionParams
+     *   When using an extension grant type, this is the set of parameters used
+     *   by that extension.
+     *
+     * @param array $config Configuration array
+     */
+    public function __construct(array $config)
+    {
+        $opts = array_merge([
+            'expiry' => self::DEFAULT_EXPIRY_SECONDS,
+            'extensionParams' => [],
+            'authorizationUri' => null,
+            'redirectUri' => null,
+            'tokenCredentialUri' => null,
+            'state' => null,
+            'username' => null,
+            'password' => null,
+            'clientId' => null,
+            'clientSecret' => null,
+            'issuer' => null,
+            'sub' => null,
+            'audience' => null,
+            'signingKey' => null,
+            'signingAlgorithm' => null,
+            'scope' => null,
+        ], $config);
+
+        $this->setAuthorizationUri($opts['authorizationUri']);
+        $this->setRedirectUri($opts['redirectUri']);
+        $this->setTokenCredentialUri($opts['tokenCredentialUri']);
+        $this->setState($opts['state']);
+        $this->setUsername($opts['username']);
+        $this->setPassword($opts['password']);
+        $this->setClientId($opts['clientId']);
+        $this->setClientSecret($opts['clientSecret']);
+        $this->setIssuer($opts['issuer']);
+        $this->setSub($opts['sub']);
+        $this->setExpiry($opts['expiry']);
+        $this->setAudience($opts['audience']);
+        $this->setSigningKey($opts['signingKey']);
+        $this->setSigningAlgorithm($opts['signingAlgorithm']);
+        $this->setScope($opts['scope']);
+        $this->setExtensionParams($opts['extensionParams']);
+        $this->updateToken($opts);
     }
-    return $result;
-  }
 
-  /**
-   * Sets the authorization server's HTTP endpoint capable of authenticating
-   * the end-user and obtaining authorization.
-   *
-   * @param string $uri
-   */
-  public function setAuthorizationUri($uri)
-  {
-    $this->authorizationUri = $this->coerceUri($uri);
-  }
-
-  /**
-   * Gets the authorization server's HTTP endpoint capable of authenticating
-   * the end-user and obtaining authorization.
-   */
-  public function getAuthorizationUri()
-  {
-    return $this->authorizationUri;
-  }
-
-  /**
-   * Gets the authorization server's HTTP endpoint capable of issuing tokens
-   * and refreshing expired tokens.
-   */
-  public function getTokenCredentialUri()
-  {
-    return $this->tokenCredentialUri;
-  }
-
-  /**
-   * Sets the authorization server's HTTP endpoint capable of issuing tokens
-   * and refreshing expired tokens.
-   *
-   * @param string $uri
-   */
-  public function setTokenCredentialUri($uri)
-  {
-    $this->tokenCredentialUri = $this->coerceUri($uri);
-  }
-
-  /**
-   * Gets the redirection URI used in the initial request.
-   */
-  public function getRedirectUri()
-  {
-    return $this->redirectUri;
-  }
-
-  /**
-   * Sets the redirection URI used in the initial request.
-   *
-   * @param string $uri
-   */
-  public function setRedirectUri($uri)
-  {
-    if (is_null($uri)) {
-      $this->redirectUri = null;
-      return;
-    }
-    // redirect URI must be absolute
-    if (!$this->isAbsoluteUri($uri)) {
-      // "postmessage" is a reserved URI string in Google-land
-      // @see https://developers.google.com/identity/sign-in/web/server-side-flow
-      if ('postmessage' !== (string) $uri) {
-        throw new InvalidArgumentException(
-          'Redirect URI must be absolute');
-      }
-    }
-    $this->redirectUri = (string) $uri;
-  }
-
-  /**
-   * Gets the scope of the access requests as a space-delimited String.
-   */
-  public function getScope()
-  {
-    if (is_null($this->scope)) {
-      return $this->scope;
-    }
-    return implode(' ', $this->scope);
-  }
-
-  /**
-   * Sets the scope of the access request, expressed either as an Array or as
-   * a space-delimited String.
-   *
-   * @param string|array $scope
-   *
-   * @throws InvalidArgumentException
-   */
-  public function setScope($scope)
-  {
-    if (is_null($scope)) {
-      $this->scope = null;
-    } else if (is_string($scope)) {
-      $this->scope = explode(' ', $scope);
-    } else if (is_array($scope)) {
-      foreach ($scope as $s) {
-        $pos = strpos($s, ' ');
-        if ($pos !== false) {
-          throw new InvalidArgumentException(
-              'array scope values should not contain spaces');
+    /**
+     * Verifies the idToken if present.
+     *
+     * - if none is present, return null
+     * - if present, but invalid, raises DomainException.
+     * - otherwise returns the payload in the idtoken as a PHP object.
+     *
+     * if $publicKey is null, the key is decoded without being verified.
+     *
+     * @param string $publicKey The public key to use to authenticate the token
+     * @param array $allowed_algs List of supported verification algorithms
+     *
+     * @return null|object
+     */
+    public function verifyIdToken($publicKey = null, $allowed_algs = array())
+    {
+        $idToken = $this->getIdToken();
+        if (is_null($idToken)) {
+            return;
         }
-      }
-      $this->scope = $scope;
-    } else {
-      throw new InvalidArgumentException(
-          'scopes should be a string or array of strings');
-    }
-  }
 
-  /**
-   * Gets the current grant type.
-   */
-  public function getGrantType()
-  {
-    if (!is_null($this->grantType)) {
-      return $this->grantType;
+        $resp = $this->jwtDecode($idToken, $publicKey, $allowed_algs);
+        if (!property_exists($resp, 'aud')) {
+            throw new \DomainException('No audience found the id token');
+        }
+        if ($resp->aud != $this->getAudience()) {
+            throw new \DomainException('Wrong audience present in the id token');
+        }
+
+        return $resp;
     }
 
-    // Returns the inferred grant type, based on the current object instance
-    // state.
-    if (!is_null($this->code)) {
-      return 'authorization_code';
-    } else if (!is_null($this->refreshToken)) {
-      return 'refresh_token';
-    } else if (!is_null($this->username) && !is_null($this->password)) {
-      return 'password';
-    } else if (!is_null($this->issuer) && !is_null($this->signingKey)) {
-      return self::JWT_URN;
-    } else {
-      return null;
-    }
-  }
+    /**
+     * Obtains the encoded jwt from the instance data.
+     *
+     * @param array $config array optional configuration parameters
+     *
+     * @return string
+     */
+    public function toJwt(array $config = [])
+    {
+        if (is_null($this->getSigningKey())) {
+            throw new \DomainException('No signing key available');
+        }
+        if (is_null($this->getSigningAlgorithm())) {
+            throw new \DomainException('No signing algorithm specified');
+        }
+        $now = time();
 
-  /**
-   * Sets the current grant type.
-   *
-   * @param $grantType
-   *
-   * @throws InvalidArgumentException
-   */
-  public function setGrantType($grantType)
-  {
-    if (in_array($grantType, self::$knownGrantTypes)) {
-      $this->grantType = $grantType;
-    } else {
-      // validate URI
-      if (!$this->isAbsoluteUri($grantType)) {
-        throw new InvalidArgumentException(
-          'invalid grant type');
-      }
-      $this->grantType = (string)$grantType;
-    }
-  }
+        $opts = array_merge([
+            'skew' => self::DEFAULT_SKEW_SECONDS,
+        ], $config);
 
-  /**
-   * Gets an arbitrary string designed to allow the client to maintain state.
-   */
-  public function getState()
-  {
-    return $this->state;
-  }
+        $assertion = [
+            'iss' => $this->getIssuer(),
+            'aud' => $this->getAudience(),
+            'exp' => ($now + $this->getExpiry()),
+            'iat' => ($now - $opts['skew']),
+        ];
+        foreach ($assertion as $k => $v) {
+            if (is_null($v)) {
+                throw new \DomainException($k.' should not be null');
+            }
+        }
+        if (!(is_null($this->getScope()))) {
+            $assertion['scope'] = $this->getScope();
+        }
+        if (!(is_null($this->getSub()))) {
+            $assertion['sub'] = $this->getSub();
+        }
 
-  /**
-   * Sets an arbitrary string designed to allow the client to maintain state.
-   *
-   * @param string $state
-   */
-  public function setState($state)
-  {
-    $this->state = $state;
-  }
-
-  /**
-   * Gets the authorization code issued to this client.
-   */
-  public function getCode()
-  {
-    return $this->code;
-  }
-
-  /**
-   * Sets the authorization code issued to this client.
-   *
-   * @param string $code
-   */
-  public function setCode($code)
-  {
-    $this->code = $code;
-  }
-
-  /**
-   * Gets the resource owner's username.
-   */
-  public function getUsername()
-  {
-    return $this->username;
-  }
-
-  /**
-   * Sets the resource owner's username.
-   *
-   * @param string $username
-   */
-  public function setUsername($username)
-  {
-    $this->username = $username;
-  }
-
-  /**
-   * Gets the resource owner's password.
-   */
-  public function getPassword()
-  {
-    return $this->password;
-  }
-
-  /**
-   * Sets the resource owner's password.
-   *
-   * @param $password
-   */
-  public function setPassword($password)
-  {
-    $this->password = $password;
-  }
-
-  /**
-   * Sets a unique identifier issued to the client to identify itself to the
-   * authorization server.
-   */
-  public function getClientId()
-  {
-    return $this->clientId;
-  }
-
-  /**
-   * Sets a unique identifier issued to the client to identify itself to the
-   * authorization server.
-   *
-   * @param $clientId
-   */
-  public function setClientId($clientId)
-  {
-    $this->clientId = $clientId;
-  }
-
-  /**
-   * Gets a shared symmetric secret issued by the authorization server, which
-   * is used to authenticate the client.
-   */
-  public function getClientSecret()
-  {
-    return $this->clientSecret;
-  }
-
-  /**
-   * Sets a shared symmetric secret issued by the authorization server, which
-   * is used to authenticate the client.
-   *
-   * @param $clientSecret
-   */
-  public function setClientSecret($clientSecret)
-  {
-    $this->clientSecret = $clientSecret;
-  }
-
-  /**
-   * Gets the Issuer ID when using assertion profile.
-   */
-  public function getIssuer()
-  {
-    return $this->issuer;
-  }
-
-  /**
-   * Sets the Issuer ID when using assertion profile.
-   *
-   * @param string $issuer
-   */
-  public function setIssuer($issuer)
-  {
-    $this->issuer = $issuer;
-  }
-
-  /**
-   * Gets the target sub when issuing assertions.
-   */
-  public function getSub()
-  {
-    return $this->sub;
-  }
-
-  /**
-   * Sets the target sub when issuing assertions.
-   *
-   * @param string $sub
-   */
-  public function setSub($sub)
-  {
-    $this->sub = $sub;
-  }
-
-  /**
-   * Gets the target audience when issuing assertions.
-   */
-  public function getAudience()
-  {
-    return $this->audience;
-  }
-
-  /**
-   * Sets the target audience when issuing assertions.
-   *
-   * @param string $audience
-   */
-  public function setAudience($audience)
-  {
-    $this->audience = $audience;
-  }
-
-  /**
-   * Gets the signing key when using an assertion profile.
-   */
-  public function getSigningKey()
-  {
-    return $this->signingKey;
-  }
-
-  /**
-   * Sets the signing key when using an assertion profile.
-   *
-   * @param string $signingKey
-   */
-  public function setSigningKey($signingKey)
-  {
-    $this->signingKey = $signingKey;
-  }
-
-  /**
-   * Gets the signing algorithm when using an assertion profile.
-   *
-   * @return string
-   */
-  public function getSigningAlgorithm()
-  {
-    return $this->signingAlgorithm;
-  }
-
-  /**
-   * Sets the signing algorithm when using an assertion profile.
-   *
-   * @param string $signingAlgorithm
-   */
-  public function setSigningAlgorithm($signingAlgorithm)
-  {
-    if (is_null($signingAlgorithm)) {
-      $this->signingAlgorithm = null;
-    } else if (!in_array($signingAlgorithm, self::$knownSigningAlgorithms)) {
-      throw new InvalidArgumentException('unknown signing algorithm');
-    } else {
-      $this->signingAlgorithm = $signingAlgorithm;
-    }
-  }
-
-  /**
-   * Gets the set of parameters used by extension when using an extension
-   * grant type.
-   */
-  public function getExtensionParams()
-  {
-    return $this->extensionParams;
-  }
-
-  /**
-   * Sets the set of parameters used by extension when using an extension
-   * grant type.
-   *
-   * @param $extensionParams
-   */
-  public function setExtensionParams($extensionParams)
-  {
-    $this->extensionParams = $extensionParams;
-  }
-
-  /**
-   * Gets the number of seconds assertions are valid for.
-   */
-  public function getExpiry()
-  {
-    return $this->expiry;
-  }
-
-  /**
-   * Sets the number of seconds assertions are valid for.
-   *
-   * @param int $expiry
-   */
-  public function setExpiry($expiry)
-  {
-    $this->expiry = $expiry;
-  }
-
-  /**
-   * Gets the lifetime of the access token in seconds.
-   */
-  public function getExpiresIn()
-  {
-    return $this->expiresIn;
-  }
-
-  /**
-   * Sets the lifetime of the access token in seconds.
-   *
-   * @param int $expiresIn
-   */
-  public function setExpiresIn($expiresIn)
-  {
-    if (is_null($expiresIn)) {
-      $this->expiresIn = null;
-      $this->issuedAt = null;
-    } else {
-      $this->issuedAt = time();
-      $this->expiresIn = (int) $expiresIn;
-    }
-  }
-
-  /**
-   * Gets the time the current access token expires at.
-   */
-  public function getExpiresAt()
-  {
-    if (!is_null($this->expiresAt)) {
-      return $this->expiresAt;
-    } else if (!is_null($this->issuedAt) && !is_null($this->expiresIn)) {
-      return $this->issuedAt + $this->expiresIn;
-    }
-    return null;
-  }
-
-  /**
-   * Returns true if the acccess token has expired.
-   */
-  public function isExpired()
-  {
-    $expiration = $this->getExpiresAt();
-    $now = time();
-    return (!is_null($expiration) && $now >= $expiration);
-  }
-
-  /**
-   * Sets the time the current access token expires at.
-   *
-   * @param int $expiresAt
-   */
-  public function setExpiresAt($expiresAt)
-  {
-    $this->expiresAt = $expiresAt;
-  }
-
-  /**
-   * Gets the time the current access token was issued at.
-   */
-  public function getIssuedAt()
-  {
-    return $this->issuedAt;
-  }
-
-  /**
-   * Sets the time the current access token was issued at.
-   *
-   * @param int $issuedAt
-   */
-  public function setIssuedAt($issuedAt)
-  {
-    $this->issuedAt = $issuedAt;
-  }
-
-  /**
-   * Gets the current access token.
-   */
-  public function getAccessToken()
-  {
-    return $this->accessToken;
-  }
-
-  /**
-   * Sets the current access token.
-   *
-   * @param string $accessToken
-   */
-  public function setAccessToken($accessToken)
-  {
-    $this->accessToken = $accessToken;
-  }
-
-  /**
-   * Gets the current ID token.
-   */
-  public function getIdToken()
-  {
-    return $this->idToken;
-  }
-
-  /**
-   * Sets the current ID token.
-   *
-   * @param $idToken
-   */
-  public function setIdToken($idToken)
-  {
-    $this->idToken = $idToken;
-  }
-
-  /**
-   * Gets the refresh token associated with the current access token.
-   */
-  public function getRefreshToken()
-  {
-    return $this->refreshToken;
-  }
-
-  /**
-   * Sets the refresh token associated with the current access token.
-   *
-   * @param $refreshToken
-   */
-  public function setRefreshToken($refreshToken)
-  {
-    $this->refreshToken = $refreshToken;
-  }
-
-  /**
-   * The expiration of the last received token
-   *
-   * @return array
-   */
-  public function getLastReceivedToken()
-  {
-    if ($token = $this->getAccessToken()) {
-      return [
-        'access_token' => $token,
-        'expires_at' => $this->getExpiresAt(),
-      ];
+        return $this->jwtEncode($assertion, $this->getSigningKey(),
+            $this->getSigningAlgorithm());
     }
 
-    return null;
-  }
+    /**
+     * Generates a request for token credentials.
+     *
+     * @return RequestInterface the authorization Url.
+     */
+    public function generateCredentialsRequest()
+    {
+        $uri = $this->getTokenCredentialUri();
+        if (is_null($uri)) {
+            throw new \DomainException('No token credential URI was set.');
+        }
 
-  /**
-   * @todo handle uri as array
-   * @param string $uri
-   * @return null|UriInterface
-   */
-  private function coerceUri($uri)
-  {
-    if (is_null($uri)) {
-      return null;
+        $grantType = $this->getGrantType();
+        $params = array('grant_type' => $grantType);
+        switch ($grantType) {
+            case 'authorization_code':
+                $params['code'] = $this->getCode();
+                $params['redirect_uri'] = $this->getRedirectUri();
+                $this->addClientCredentials($params);
+                break;
+            case 'password':
+                $params['username'] = $this->getUsername();
+                $params['password'] = $this->getPassword();
+                $this->addClientCredentials($params);
+                break;
+            case 'refresh_token':
+                $params['refresh_token'] = $this->getRefreshToken();
+                $this->addClientCredentials($params);
+                break;
+            case self::JWT_URN:
+                $params['assertion'] = $this->toJwt();
+                break;
+            default:
+                if (!is_null($this->getRedirectUri())) {
+                    # Grant type was supposed to be 'authorization_code', as there
+                    # is a redirect URI.
+                    throw new \DomainException('Missing authorization code');
+                }
+                unset($params['grant_type']);
+                if (!is_null($grantType)) {
+                    $params['grant_type'] = $grantType;
+                }
+                $params = array_merge($params, $this->getExtensionParams());
+        }
+
+        $headers = [
+            'Cache-Control' => 'no-store',
+            'Content-Type' => 'application/x-www-form-urlencoded',
+        ];
+
+        return new Request(
+            'POST',
+            $uri,
+            $headers,
+            Psr7\build_query($params)
+        );
     }
 
-    return Psr7\uri_for($uri);
-  }
+    /**
+     * Fetches the auth tokens based on the current state.
+     *
+     * @param callable $httpHandler callback which delivers psr7 request
+     *
+     * @return array the response
+     */
+    public function fetchAuthToken(callable $httpHandler = null)
+    {
+        if (is_null($httpHandler)) {
+            $httpHandler = HttpHandlerFactory::build();
+        }
 
-  /**
-   * @param string $idToken
-   * @param string|array|null $publicKey
-   * @param array $allowedAlgs
-   *
-   * @return object
-   */
-  private function jwtDecode($idToken, $publicKey, $allowedAlgs)
-  {
-    if (class_exists('Firebase\JWT\JWT')) {
-      return \Firebase\JWT\JWT::decode($idToken, $publicKey, $allowedAlgs);
+        $response = $httpHandler($this->generateCredentialsRequest());
+        $credentials = $this->parseTokenResponse($response);
+        $this->updateToken($credentials);
+
+        return $credentials;
     }
 
-    return \JWT::decode($idToken, $publicKey, $allowedAlgs);
-  }
+    /**
+     * Obtains a key that can used to cache the results of #fetchAuthToken.
+     *
+     * The key is derived from the scopes.
+     *
+     * @return string a key that may be used to cache the auth token.
+     */
+    public function getCacheKey()
+    {
+        if (is_string($this->scope)) {
+            return $this->scope;
+        } elseif (is_array($this->scope)) {
+            return implode(':', $this->scope);
+        }
 
-  private function jwtEncode($assertion, $signingKey, $signingAlgorithm)
-  {
-    if (class_exists('Firebase\JWT\JWT')) {
-      return \Firebase\JWT\JWT::encode($assertion, $signingKey,
-                       $signingAlgorithm);
+        // If scope has not set, return null to indicate no caching.
+        return;
     }
 
-    return \JWT::encode($assertion, $signingKey, $signingAlgorithm);
-  }
+    /**
+     * Parses the fetched tokens.
+     *
+     * @param ResponseInterface $resp the response.
+     *
+     * @return array the tokens parsed from the response body.
+     *
+     * @throws \Exception
+     */
+    public function parseTokenResponse(ResponseInterface $resp)
+    {
+        $body = (string)$resp->getBody();
+        if ($resp->hasHeader('Content-Type') &&
+            $resp->getHeaderLine('Content-Type') == 'application/x-www-form-urlencoded'
+        ) {
+            $res = array();
+            parse_str($body, $res);
 
-  /**
-   * Determines if the URI is absolute based on its scheme and host or path
-   * (RFC 3986)
-   *
-   * @param string $uri
-   *
-   * @return bool
-   */
-  private function isAbsoluteUri($uri)
-  {
-    $uri = $this->coerceUri($uri);
+            return $res;
+        } else {
+            // Assume it's JSON; if it's not throw an exception
+            if (null === $res = json_decode($body, true)) {
+                throw new \Exception('Invalid JSON response');
+            }
 
-    return $uri->getScheme() && ($uri->getHost() || $uri->getPath());
-  }
-
-  /**
-   * @param array $params
-   *
-   * @return array
-   */
-  private function addClientCredentials(&$params)
-  {
-    $clientId = $this->getClientId();
-    $clientSecret = $this->getClientSecret();
-
-    if ($clientId && $clientSecret) {
-      $params['client_id'] = $clientId;
-      $params['client_secret'] = $clientSecret;
+            return $res;
+        }
     }
 
-    return $params;
-  }
+    /**
+     * Updates an OAuth 2.0 client.
+     *
+     * @example
+     *   client.updateToken([
+     *     'refresh_token' => 'n4E9O119d',
+     *     'access_token' => 'FJQbwq9',
+     *     'expires_in' => 3600
+     *   ])
+     *
+     * @param array $config
+     *  The configuration parameters related to the token.
+     *
+     *  - refresh_token
+     *    The refresh token associated with the access token
+     *    to be refreshed.
+     *
+     *  - access_token
+     *    The current access token for this client.
+     *
+     *  - id_token
+     *    The current ID token for this client.
+     *
+     *  - expires_in
+     *    The time in seconds until access token expiration.
+     *
+     *  - expires_at
+     *    The time as an integer number of seconds since the Epoch
+     *
+     *  - issued_at
+     *    The timestamp that the token was issued at.
+     */
+    public function updateToken(array $config)
+    {
+        $opts = array_merge([
+            'extensionParams' => [],
+            'refresh_token' => null,
+            'access_token' => null,
+            'id_token' => null,
+            'expires' => null,
+            'expires_in' => null,
+            'expires_at' => null,
+            'issued_at' => null,
+        ], $config);
+
+        $this->setExpiresAt($opts['expires']);
+        $this->setExpiresAt($opts['expires_at']);
+        $this->setExpiresIn($opts['expires_in']);
+        // By default, the token is issued at `Time.now` when `expiresIn` is set,
+        // but this can be used to supply a more precise time.
+        if (!is_null($opts['issued_at'])) {
+            $this->setIssuedAt($opts['issued_at']);
+        }
+
+        $this->setAccessToken($opts['access_token']);
+        $this->setIdToken($opts['id_token']);
+        $this->setRefreshToken($opts['refresh_token']);
+    }
+
+    /**
+     * Builds the authorization Uri that the user should be redirected to.
+     *
+     * @param array $config configuration options that customize the return url
+     *
+     * @return UriInterface the authorization Url.
+     *
+     * @throws InvalidArgumentException
+     */
+    public function buildFullAuthorizationUri(array $config = [])
+    {
+        if (is_null($this->getAuthorizationUri())) {
+            throw new InvalidArgumentException(
+                'requires an authorizationUri to have been set');
+        }
+
+        $params = array_merge([
+            'response_type' => 'code',
+            'access_type' => 'offline',
+            'client_id' => $this->clientId,
+            'redirect_uri' => $this->redirectUri,
+            'state' => $this->state,
+            'scope' => $this->getScope(),
+        ], $config);
+
+        // Validate the auth_params
+        if (is_null($params['client_id'])) {
+            throw new InvalidArgumentException(
+                'missing the required client identifier');
+        }
+        if (is_null($params['redirect_uri'])) {
+            throw new InvalidArgumentException('missing the required redirect URI');
+        }
+        if (!empty($params['prompt']) && !empty($params['approval_prompt'])) {
+            throw new InvalidArgumentException(
+                'prompt and approval_prompt are mutually exclusive');
+        }
+
+        // Construct the uri object; return it if it is valid.
+        $result = clone $this->authorizationUri;
+        $existingParams = Psr7\parse_query($result->getQuery());
+
+        $result = $result->withQuery(
+            Psr7\build_query(array_merge($existingParams, $params))
+        );
+
+        if ($result->getScheme() != 'https') {
+            throw new InvalidArgumentException(
+                'Authorization endpoint must be protected by TLS');
+        }
+
+        return $result;
+    }
+
+    /**
+     * Sets the authorization server's HTTP endpoint capable of authenticating
+     * the end-user and obtaining authorization.
+     *
+     * @param string $uri
+     */
+    public function setAuthorizationUri($uri)
+    {
+        $this->authorizationUri = $this->coerceUri($uri);
+    }
+
+    /**
+     * Gets the authorization server's HTTP endpoint capable of authenticating
+     * the end-user and obtaining authorization.
+     */
+    public function getAuthorizationUri()
+    {
+        return $this->authorizationUri;
+    }
+
+    /**
+     * Gets the authorization server's HTTP endpoint capable of issuing tokens
+     * and refreshing expired tokens.
+     */
+    public function getTokenCredentialUri()
+    {
+        return $this->tokenCredentialUri;
+    }
+
+    /**
+     * Sets the authorization server's HTTP endpoint capable of issuing tokens
+     * and refreshing expired tokens.
+     *
+     * @param string $uri
+     */
+    public function setTokenCredentialUri($uri)
+    {
+        $this->tokenCredentialUri = $this->coerceUri($uri);
+    }
+
+    /**
+     * Gets the redirection URI used in the initial request.
+     */
+    public function getRedirectUri()
+    {
+        return $this->redirectUri;
+    }
+
+    /**
+     * Sets the redirection URI used in the initial request.
+     *
+     * @param string $uri
+     */
+    public function setRedirectUri($uri)
+    {
+        if (is_null($uri)) {
+            $this->redirectUri = null;
+
+            return;
+        }
+        // redirect URI must be absolute
+        if (!$this->isAbsoluteUri($uri)) {
+            // "postmessage" is a reserved URI string in Google-land
+            // @see https://developers.google.com/identity/sign-in/web/server-side-flow
+            if ('postmessage' !== (string)$uri) {
+                throw new InvalidArgumentException(
+                    'Redirect URI must be absolute');
+            }
+        }
+        $this->redirectUri = (string)$uri;
+    }
+
+    /**
+     * Gets the scope of the access requests as a space-delimited String.
+     */
+    public function getScope()
+    {
+        if (is_null($this->scope)) {
+            return $this->scope;
+        }
+
+        return implode(' ', $this->scope);
+    }
+
+    /**
+     * Sets the scope of the access request, expressed either as an Array or as
+     * a space-delimited String.
+     *
+     * @param string|array $scope
+     *
+     * @throws InvalidArgumentException
+     */
+    public function setScope($scope)
+    {
+        if (is_null($scope)) {
+            $this->scope = null;
+        } elseif (is_string($scope)) {
+            $this->scope = explode(' ', $scope);
+        } elseif (is_array($scope)) {
+            foreach ($scope as $s) {
+                $pos = strpos($s, ' ');
+                if ($pos !== false) {
+                    throw new InvalidArgumentException(
+                        'array scope values should not contain spaces');
+                }
+            }
+            $this->scope = $scope;
+        } else {
+            throw new InvalidArgumentException(
+                'scopes should be a string or array of strings');
+        }
+    }
+
+    /**
+     * Gets the current grant type.
+     */
+    public function getGrantType()
+    {
+        if (!is_null($this->grantType)) {
+            return $this->grantType;
+        }
+
+        // Returns the inferred grant type, based on the current object instance
+        // state.
+        if (!is_null($this->code)) {
+            return 'authorization_code';
+        } elseif (!is_null($this->refreshToken)) {
+            return 'refresh_token';
+        } elseif (!is_null($this->username) && !is_null($this->password)) {
+            return 'password';
+        } elseif (!is_null($this->issuer) && !is_null($this->signingKey)) {
+            return self::JWT_URN;
+        } else {
+            return;
+        }
+    }
+
+    /**
+     * Sets the current grant type.
+     *
+     * @param $grantType
+     *
+     * @throws InvalidArgumentException
+     */
+    public function setGrantType($grantType)
+    {
+        if (in_array($grantType, self::$knownGrantTypes)) {
+            $this->grantType = $grantType;
+        } else {
+            // validate URI
+            if (!$this->isAbsoluteUri($grantType)) {
+                throw new InvalidArgumentException(
+                    'invalid grant type');
+            }
+            $this->grantType = (string)$grantType;
+        }
+    }
+
+    /**
+     * Gets an arbitrary string designed to allow the client to maintain state.
+     */
+    public function getState()
+    {
+        return $this->state;
+    }
+
+    /**
+     * Sets an arbitrary string designed to allow the client to maintain state.
+     *
+     * @param string $state
+     */
+    public function setState($state)
+    {
+        $this->state = $state;
+    }
+
+    /**
+     * Gets the authorization code issued to this client.
+     */
+    public function getCode()
+    {
+        return $this->code;
+    }
+
+    /**
+     * Sets the authorization code issued to this client.
+     *
+     * @param string $code
+     */
+    public function setCode($code)
+    {
+        $this->code = $code;
+    }
+
+    /**
+     * Gets the resource owner's username.
+     */
+    public function getUsername()
+    {
+        return $this->username;
+    }
+
+    /**
+     * Sets the resource owner's username.
+     *
+     * @param string $username
+     */
+    public function setUsername($username)
+    {
+        $this->username = $username;
+    }
+
+    /**
+     * Gets the resource owner's password.
+     */
+    public function getPassword()
+    {
+        return $this->password;
+    }
+
+    /**
+     * Sets the resource owner's password.
+     *
+     * @param $password
+     */
+    public function setPassword($password)
+    {
+        $this->password = $password;
+    }
+
+    /**
+     * Sets a unique identifier issued to the client to identify itself to the
+     * authorization server.
+     */
+    public function getClientId()
+    {
+        return $this->clientId;
+    }
+
+    /**
+     * Sets a unique identifier issued to the client to identify itself to the
+     * authorization server.
+     *
+     * @param $clientId
+     */
+    public function setClientId($clientId)
+    {
+        $this->clientId = $clientId;
+    }
+
+    /**
+     * Gets a shared symmetric secret issued by the authorization server, which
+     * is used to authenticate the client.
+     */
+    public function getClientSecret()
+    {
+        return $this->clientSecret;
+    }
+
+    /**
+     * Sets a shared symmetric secret issued by the authorization server, which
+     * is used to authenticate the client.
+     *
+     * @param $clientSecret
+     */
+    public function setClientSecret($clientSecret)
+    {
+        $this->clientSecret = $clientSecret;
+    }
+
+    /**
+     * Gets the Issuer ID when using assertion profile.
+     */
+    public function getIssuer()
+    {
+        return $this->issuer;
+    }
+
+    /**
+     * Sets the Issuer ID when using assertion profile.
+     *
+     * @param string $issuer
+     */
+    public function setIssuer($issuer)
+    {
+        $this->issuer = $issuer;
+    }
+
+    /**
+     * Gets the target sub when issuing assertions.
+     */
+    public function getSub()
+    {
+        return $this->sub;
+    }
+
+    /**
+     * Sets the target sub when issuing assertions.
+     *
+     * @param string $sub
+     */
+    public function setSub($sub)
+    {
+        $this->sub = $sub;
+    }
+
+    /**
+     * Gets the target audience when issuing assertions.
+     */
+    public function getAudience()
+    {
+        return $this->audience;
+    }
+
+    /**
+     * Sets the target audience when issuing assertions.
+     *
+     * @param string $audience
+     */
+    public function setAudience($audience)
+    {
+        $this->audience = $audience;
+    }
+
+    /**
+     * Gets the signing key when using an assertion profile.
+     */
+    public function getSigningKey()
+    {
+        return $this->signingKey;
+    }
+
+    /**
+     * Sets the signing key when using an assertion profile.
+     *
+     * @param string $signingKey
+     */
+    public function setSigningKey($signingKey)
+    {
+        $this->signingKey = $signingKey;
+    }
+
+    /**
+     * Gets the signing algorithm when using an assertion profile.
+     *
+     * @return string
+     */
+    public function getSigningAlgorithm()
+    {
+        return $this->signingAlgorithm;
+    }
+
+    /**
+     * Sets the signing algorithm when using an assertion profile.
+     *
+     * @param string $signingAlgorithm
+     */
+    public function setSigningAlgorithm($signingAlgorithm)
+    {
+        if (is_null($signingAlgorithm)) {
+            $this->signingAlgorithm = null;
+        } elseif (!in_array($signingAlgorithm, self::$knownSigningAlgorithms)) {
+            throw new InvalidArgumentException('unknown signing algorithm');
+        } else {
+            $this->signingAlgorithm = $signingAlgorithm;
+        }
+    }
+
+    /**
+     * Gets the set of parameters used by extension when using an extension
+     * grant type.
+     */
+    public function getExtensionParams()
+    {
+        return $this->extensionParams;
+    }
+
+    /**
+     * Sets the set of parameters used by extension when using an extension
+     * grant type.
+     *
+     * @param $extensionParams
+     */
+    public function setExtensionParams($extensionParams)
+    {
+        $this->extensionParams = $extensionParams;
+    }
+
+    /**
+     * Gets the number of seconds assertions are valid for.
+     */
+    public function getExpiry()
+    {
+        return $this->expiry;
+    }
+
+    /**
+     * Sets the number of seconds assertions are valid for.
+     *
+     * @param int $expiry
+     */
+    public function setExpiry($expiry)
+    {
+        $this->expiry = $expiry;
+    }
+
+    /**
+     * Gets the lifetime of the access token in seconds.
+     */
+    public function getExpiresIn()
+    {
+        return $this->expiresIn;
+    }
+
+    /**
+     * Sets the lifetime of the access token in seconds.
+     *
+     * @param int $expiresIn
+     */
+    public function setExpiresIn($expiresIn)
+    {
+        if (is_null($expiresIn)) {
+            $this->expiresIn = null;
+            $this->issuedAt = null;
+        } else {
+            $this->issuedAt = time();
+            $this->expiresIn = (int)$expiresIn;
+        }
+    }
+
+    /**
+     * Gets the time the current access token expires at.
+     */
+    public function getExpiresAt()
+    {
+        if (!is_null($this->expiresAt)) {
+            return $this->expiresAt;
+        } elseif (!is_null($this->issuedAt) && !is_null($this->expiresIn)) {
+            return $this->issuedAt + $this->expiresIn;
+        }
+
+        return;
+    }
+
+    /**
+     * Returns true if the acccess token has expired.
+     */
+    public function isExpired()
+    {
+        $expiration = $this->getExpiresAt();
+        $now = time();
+
+        return !is_null($expiration) && $now >= $expiration;
+    }
+
+    /**
+     * Sets the time the current access token expires at.
+     *
+     * @param int $expiresAt
+     */
+    public function setExpiresAt($expiresAt)
+    {
+        $this->expiresAt = $expiresAt;
+    }
+
+    /**
+     * Gets the time the current access token was issued at.
+     */
+    public function getIssuedAt()
+    {
+        return $this->issuedAt;
+    }
+
+    /**
+     * Sets the time the current access token was issued at.
+     *
+     * @param int $issuedAt
+     */
+    public function setIssuedAt($issuedAt)
+    {
+        $this->issuedAt = $issuedAt;
+    }
+
+    /**
+     * Gets the current access token.
+     */
+    public function getAccessToken()
+    {
+        return $this->accessToken;
+    }
+
+    /**
+     * Sets the current access token.
+     *
+     * @param string $accessToken
+     */
+    public function setAccessToken($accessToken)
+    {
+        $this->accessToken = $accessToken;
+    }
+
+    /**
+     * Gets the current ID token.
+     */
+    public function getIdToken()
+    {
+        return $this->idToken;
+    }
+
+    /**
+     * Sets the current ID token.
+     *
+     * @param $idToken
+     */
+    public function setIdToken($idToken)
+    {
+        $this->idToken = $idToken;
+    }
+
+    /**
+     * Gets the refresh token associated with the current access token.
+     */
+    public function getRefreshToken()
+    {
+        return $this->refreshToken;
+    }
+
+    /**
+     * Sets the refresh token associated with the current access token.
+     *
+     * @param $refreshToken
+     */
+    public function setRefreshToken($refreshToken)
+    {
+        $this->refreshToken = $refreshToken;
+    }
+
+    /**
+     * The expiration of the last received token.
+     *
+     * @return array
+     */
+    public function getLastReceivedToken()
+    {
+        if ($token = $this->getAccessToken()) {
+            return [
+                'access_token' => $token,
+                'expires_at' => $this->getExpiresAt(),
+            ];
+        }
+
+        return;
+    }
+
+    /**
+     * @todo handle uri as array
+     *
+     * @param string $uri
+     *
+     * @return null|UriInterface
+     */
+    private function coerceUri($uri)
+    {
+        if (is_null($uri)) {
+            return;
+        }
+
+        return Psr7\uri_for($uri);
+    }
+
+    /**
+     * @param string $idToken
+     * @param string|array|null $publicKey
+     * @param array $allowedAlgs
+     *
+     * @return object
+     */
+    private function jwtDecode($idToken, $publicKey, $allowedAlgs)
+    {
+        if (class_exists('Firebase\JWT\JWT')) {
+            return \Firebase\JWT\JWT::decode($idToken, $publicKey, $allowedAlgs);
+        }
+
+        return \JWT::decode($idToken, $publicKey, $allowedAlgs);
+    }
+
+    private function jwtEncode($assertion, $signingKey, $signingAlgorithm)
+    {
+        if (class_exists('Firebase\JWT\JWT')) {
+            return \Firebase\JWT\JWT::encode($assertion, $signingKey,
+                $signingAlgorithm);
+        }
+
+        return \JWT::encode($assertion, $signingKey, $signingAlgorithm);
+    }
+
+    /**
+     * Determines if the URI is absolute based on its scheme and host or path
+     * (RFC 3986).
+     *
+     * @param string $uri
+     *
+     * @return bool
+     */
+    private function isAbsoluteUri($uri)
+    {
+        $uri = $this->coerceUri($uri);
+
+        return $uri->getScheme() && ($uri->getHost() || $uri->getPath());
+    }
+
+    /**
+     * @param array $params
+     *
+     * @return array
+     */
+    private function addClientCredentials(&$params)
+    {
+        $clientId = $this->getClientId();
+        $clientSecret = $this->getClientSecret();
+
+        if ($clientId && $clientSecret) {
+            $params['client_id'] = $clientId;
+            $params['client_secret'] = $clientSecret;
+        }
+
+        return $params;
+    }
 }

--- a/src/OAuth2.php
+++ b/src/OAuth2.php
@@ -361,7 +361,7 @@ class OAuth2 implements FetchAuthTokenInterface
     {
         $idToken = $this->getIdToken();
         if (is_null($idToken)) {
-            return;
+            return null;
         }
 
         $resp = $this->jwtDecode($idToken, $publicKey, $allowed_algs);
@@ -512,7 +512,7 @@ class OAuth2 implements FetchAuthTokenInterface
         }
 
         // If scope has not set, return null to indicate no caching.
-        return;
+        return null;
     }
 
     /**
@@ -671,6 +671,8 @@ class OAuth2 implements FetchAuthTokenInterface
     /**
      * Gets the authorization server's HTTP endpoint capable of authenticating
      * the end-user and obtaining authorization.
+     *
+     * @return UriInterface
      */
     public function getAuthorizationUri()
     {
@@ -680,6 +682,8 @@ class OAuth2 implements FetchAuthTokenInterface
     /**
      * Gets the authorization server's HTTP endpoint capable of issuing tokens
      * and refreshing expired tokens.
+     *
+     * @return string
      */
     public function getTokenCredentialUri()
     {
@@ -699,6 +703,8 @@ class OAuth2 implements FetchAuthTokenInterface
 
     /**
      * Gets the redirection URI used in the initial request.
+     *
+     * @return string
      */
     public function getRedirectUri()
     {
@@ -731,6 +737,8 @@ class OAuth2 implements FetchAuthTokenInterface
 
     /**
      * Gets the scope of the access requests as a space-delimited String.
+     *
+     * @return string
      */
     public function getScope()
     {
@@ -772,6 +780,8 @@ class OAuth2 implements FetchAuthTokenInterface
 
     /**
      * Gets the current grant type.
+     *
+     * @return string
      */
     public function getGrantType()
     {
@@ -790,7 +800,7 @@ class OAuth2 implements FetchAuthTokenInterface
         } elseif (!is_null($this->issuer) && !is_null($this->signingKey)) {
             return self::JWT_URN;
         } else {
-            return;
+            return null;
         }
     }
 
@@ -817,6 +827,8 @@ class OAuth2 implements FetchAuthTokenInterface
 
     /**
      * Gets an arbitrary string designed to allow the client to maintain state.
+     *
+     * @return string
      */
     public function getState()
     {
@@ -1089,6 +1101,8 @@ class OAuth2 implements FetchAuthTokenInterface
 
     /**
      * Gets the time the current access token expires at.
+     *
+     * @return int
      */
     public function getExpiresAt()
     {
@@ -1098,11 +1112,13 @@ class OAuth2 implements FetchAuthTokenInterface
             return $this->issuedAt + $this->expiresIn;
         }
 
-        return;
+        return null;
     }
 
     /**
      * Returns true if the acccess token has expired.
+     *
+     * @return bool
      */
     public function isExpired()
     {
@@ -1208,7 +1224,7 @@ class OAuth2 implements FetchAuthTokenInterface
             ];
         }
 
-        return;
+        return null;
     }
 
     /**

--- a/src/Subscriber/AuthTokenSubscriber.php
+++ b/src/Subscriber/AuthTokenSubscriber.php
@@ -41,16 +41,24 @@ class AuthTokenSubscriber implements SubscriberInterface
 
     const DEFAULT_CACHE_LIFETIME = 1500;
 
-    /** @var An implementation of CacheInterface */
+    /**
+     * @var CacheInterface
+     */
     private $cache;
 
-    /** @var callable */
+    /**
+     * @var callable
+     */
     private $httpHandler;
 
-    /** @var An implementation of FetchAuthTokenInterface */
+    /**
+     * @var FetchAuthTokenInterface
+     */
     private $fetcher;
 
-    /** @var cache configuration */
+    /**
+     * @var array
+     */
     private $cacheConfig;
 
     /**
@@ -78,7 +86,9 @@ class AuthTokenSubscriber implements SubscriberInterface
         }
     }
 
-    /* Implements SubscriberInterface */
+    /**
+     * @return array
+     */
     public function getEvents()
     {
         return ['before' => ['onBefore', RequestEvents::SIGN_REQUEST]];
@@ -106,6 +116,8 @@ class AuthTokenSubscriber implements SubscriberInterface
      *   $client->getEmitter()->attach($subscriber);
      *
      *   $res = $client->get('myproject/taskqueues/myqueue');
+     *
+     * @param BeforeEvent $event
      */
     public function onBefore(BeforeEvent $event)
     {

--- a/src/Subscriber/AuthTokenSubscriber.php
+++ b/src/Subscriber/AuthTokenSubscriber.php
@@ -37,101 +37,102 @@ use GuzzleHttp\Event\SubscriberInterface;
  */
 class AuthTokenSubscriber implements SubscriberInterface
 {
-  use CacheTrait;
+    use CacheTrait;
 
-  const DEFAULT_CACHE_LIFETIME = 1500;
+    const DEFAULT_CACHE_LIFETIME = 1500;
 
-  /** @var An implementation of CacheInterface */
-  private $cache;
+    /** @var An implementation of CacheInterface */
+    private $cache;
 
-  /** @var callable */
-  private $httpHandler;
+    /** @var callable */
+    private $httpHandler;
 
-  /** @var An implementation of FetchAuthTokenInterface */
-  private $fetcher;
+    /** @var An implementation of FetchAuthTokenInterface */
+    private $fetcher;
 
-  /** @var cache configuration */
-  private $cacheConfig;
+    /** @var cache configuration */
+    private $cacheConfig;
 
-  /**
-   * Creates a new AuthTokenSubscriber.
-   *
-   * @param FetchAuthTokenInterface $fetcher is used to fetch the auth token
-   * @param array $cacheConfig configures the cache
-   * @param CacheInterface $cache (optional) caches the token.
-   * @param callable $httpHandler (optional) http client to fetch the token.
-   */
-  public function __construct(
-    FetchAuthTokenInterface $fetcher,
-    array $cacheConfig = null,
-    CacheInterface $cache = null,
-    callable $httpHandler = null
-  ) {
-    $this->fetcher = $fetcher;
-    $this->httpHandler = $httpHandler;
-    if (!is_null($cache)) {
-      $this->cache = $cache;
-      $this->cacheConfig = array_merge([
-        'lifetime' => self::DEFAULT_CACHE_LIFETIME,
-        'prefix'   => ''
-      ], $cacheConfig);
-    }
-  }
-
-  /* Implements SubscriberInterface */
-  public function getEvents()
-  {
-    return ['before' => ['onBefore', RequestEvents::SIGN_REQUEST]];
-  }
-
-  /**
-   * Updates the request with an Authorization header when auth is 'fetched_auth_token'.
-   *
-   *   use GuzzleHttp\Client;
-   *   use Google\Auth\OAuth2;
-   *   use Google\Auth\Subscriber\AuthTokenSubscriber;
-   *
-   *   $config = [..<oauth config param>.];
-   *   $oauth2 = new OAuth2($config)
-   *   $subscriber = new AuthTokenSubscriber(
-   *       $oauth2,
-   *       ['prefix' => 'OAuth2::'],
-   *       $cache = new Memcache()
-   *   );
-   *
-   *   $client = new Client([
-   *      'base_url' => 'https://www.googleapis.com/taskqueue/v1beta2/projects/',
-   *      'defaults' => ['auth' => 'google_auth']
-   *   ]);
-   *   $client->getEmitter()->attach($subscriber);
-   *
-   *   $res = $client->get('myproject/taskqueues/myqueue');
-   */
-  public function onBefore(BeforeEvent $event)
-  {
-    // Requests using "auth"="google_auth" will be authorized.
-    $request = $event->getRequest();
-    if ($request->getConfig()['auth'] != 'google_auth') {
-      return;
+    /**
+     * Creates a new AuthTokenSubscriber.
+     *
+     * @param FetchAuthTokenInterface $fetcher is used to fetch the auth token
+     * @param array $cacheConfig configures the cache
+     * @param CacheInterface $cache (optional) caches the token.
+     * @param callable $httpHandler (optional) http client to fetch the token.
+     */
+    public function __construct(
+        FetchAuthTokenInterface $fetcher,
+        array $cacheConfig = null,
+        CacheInterface $cache = null,
+        callable $httpHandler = null
+    ) {
+        $this->fetcher = $fetcher;
+        $this->httpHandler = $httpHandler;
+        if (!is_null($cache)) {
+            $this->cache = $cache;
+            $this->cacheConfig = array_merge([
+                'lifetime' => self::DEFAULT_CACHE_LIFETIME,
+                'prefix' => '',
+            ], $cacheConfig);
+        }
     }
 
-    // Use the cached value if its available.
-    //
-    // TODO: correct caching; update the call to setCachedValue to set the expiry
-    // to the value returned with the auth token.
-    //
-    // TODO: correct caching; enable the cache to be cleared.
-    $cached = $this->getCachedValue();
-    if (!empty($cached)) {
-      $request->setHeader('Authorization', 'Bearer ' . $cached);
-      return;
+    /* Implements SubscriberInterface */
+    public function getEvents()
+    {
+        return ['before' => ['onBefore', RequestEvents::SIGN_REQUEST]];
     }
 
-    // Fetch the auth token.
-    $auth_tokens = $this->fetcher->fetchAuthToken($this->httpHandler);
-    if (array_key_exists('access_token', $auth_tokens)) {
-      $request->setHeader('Authorization', 'Bearer ' . $auth_tokens['access_token']);
-      $this->setCachedValue($auth_tokens['access_token']);
+    /**
+     * Updates the request with an Authorization header when auth is 'fetched_auth_token'.
+     *
+     *   use GuzzleHttp\Client;
+     *   use Google\Auth\OAuth2;
+     *   use Google\Auth\Subscriber\AuthTokenSubscriber;
+     *
+     *   $config = [..<oauth config param>.];
+     *   $oauth2 = new OAuth2($config)
+     *   $subscriber = new AuthTokenSubscriber(
+     *       $oauth2,
+     *       ['prefix' => 'OAuth2::'],
+     *       $cache = new Memcache()
+     *   );
+     *
+     *   $client = new Client([
+     *      'base_url' => 'https://www.googleapis.com/taskqueue/v1beta2/projects/',
+     *      'defaults' => ['auth' => 'google_auth']
+     *   ]);
+     *   $client->getEmitter()->attach($subscriber);
+     *
+     *   $res = $client->get('myproject/taskqueues/myqueue');
+     */
+    public function onBefore(BeforeEvent $event)
+    {
+        // Requests using "auth"="google_auth" will be authorized.
+        $request = $event->getRequest();
+        if ($request->getConfig()['auth'] != 'google_auth') {
+            return;
+        }
+
+        // Use the cached value if its available.
+        //
+        // TODO: correct caching; update the call to setCachedValue to set the expiry
+        // to the value returned with the auth token.
+        //
+        // TODO: correct caching; enable the cache to be cleared.
+        $cached = $this->getCachedValue();
+        if (!empty($cached)) {
+            $request->setHeader('Authorization', 'Bearer '.$cached);
+
+            return;
+        }
+
+        // Fetch the auth token.
+        $auth_tokens = $this->fetcher->fetchAuthToken($this->httpHandler);
+        if (array_key_exists('access_token', $auth_tokens)) {
+            $request->setHeader('Authorization', 'Bearer '.$auth_tokens['access_token']);
+            $this->setCachedValue($auth_tokens['access_token']);
+        }
     }
-  }
 }

--- a/src/Subscriber/ScopedAccessTokenSubscriber.php
+++ b/src/Subscriber/ScopedAccessTokenSubscriber.php
@@ -19,9 +19,9 @@ namespace Google\Auth\Subscriber;
 
 use Google\Auth\CacheInterface;
 use Google\Auth\CacheTrait;
+use GuzzleHttp\Event\BeforeEvent;
 use GuzzleHttp\Event\RequestEvents;
 use GuzzleHttp\Event\SubscriberInterface;
-use GuzzleHttp\Event\BeforeEvent;
 
 /**
  * ScopedAccessTokenSubscriber is a Guzzle Subscriber that adds an Authorization
@@ -37,126 +37,128 @@ use GuzzleHttp\Event\BeforeEvent;
  */
 class ScopedAccessTokenSubscriber implements SubscriberInterface
 {
-  use CacheTrait;
+    use CacheTrait;
 
-  const DEFAULT_CACHE_LIFETIME = 1500;
+    const DEFAULT_CACHE_LIFETIME = 1500;
 
-  /** @var An implementation of CacheInterface */
-  private $cache;
+    /** @var An implementation of CacheInterface */
+    private $cache;
 
-  /** @var The access token generator function  */
-  private $tokenFunc;
+    /** @var The access token generator function */
+    private $tokenFunc;
 
-  /** @var The scopes used to generate the token */
-  private $scopes;
+    /** @var The scopes used to generate the token */
+    private $scopes;
 
-  /** @var cache configuration */
-  private $cacheConfig;
+    /** @var cache configuration */
+    private $cacheConfig;
 
-  /**
-   * Creates a new ScopedAccessTokenSubscriber.
-   *
-   * @param callable $tokenFunc a token generator function
-   * @param array|string $scopes the token authentication scopes
-   * @param array $cacheConfig configuration for the cache when it's present
-   * @param CacheInterface $cache an implementation of CacheInterface
-   */
-  public function __construct(
-    callable $tokenFunc,
-    $scopes,
-    array $cacheConfig = null,
-    CacheInterface $cache = null
-  ) {
-    $this->tokenFunc = $tokenFunc;
-    if (!(is_string($scopes) || is_array($scopes))) {
-      throw new \InvalidArgumentException(
-          'wants scope should be string or array');
-    }
-    $this->scopes = $scopes;
+    /**
+     * Creates a new ScopedAccessTokenSubscriber.
+     *
+     * @param callable $tokenFunc a token generator function
+     * @param array|string $scopes the token authentication scopes
+     * @param array $cacheConfig configuration for the cache when it's present
+     * @param CacheInterface $cache an implementation of CacheInterface
+     */
+    public function __construct(
+        callable $tokenFunc,
+        $scopes,
+        array $cacheConfig = null,
+        CacheInterface $cache = null
+    ) {
+        $this->tokenFunc = $tokenFunc;
+        if (!(is_string($scopes) || is_array($scopes))) {
+            throw new \InvalidArgumentException(
+                'wants scope should be string or array');
+        }
+        $this->scopes = $scopes;
 
-    if (!is_null($cache)) {
-      $this->cache = $cache;
-      $this->cacheConfig = array_merge([
-        'lifetime' => self::DEFAULT_CACHE_LIFETIME,
-        'prefix'   => ''
-      ], $cacheConfig);
-    }
-  }
-
-  /* Implements SubscriberInterface */
-  public function getEvents()
-  {
-    return ['before' => ['onBefore', RequestEvents::SIGN_REQUEST]];
-  }
-
-  /**
-   * Updates the request with an Authorization header when auth is 'scoped'.
-   *
-   *   E.g this could be used to authenticate using the AppEngine
-   *   AppIdentityService.
-   *
-   *   use google\appengine\api\app_identity\AppIdentityService;
-   *   use Google\Auth\Subscriber\ScopedAccessTokenSubscriber;
-   *   use GuzzleHttp\Client;
-   *
-   *   $scope = 'https://www.googleapis.com/auth/taskqueue'
-   *   $subscriber = new ScopedAccessToken(
-   *       'AppIdentityService::getAccessToken',
-   *       $scope,
-   *       ['prefix' => 'Google\Auth\ScopedAccessToken::'],
-   *       $cache = new Memcache()
-   *   );
-   *
-   *   $client = new Client([
-   *       'base_url' => 'https://www.googleapis.com/taskqueue/v1beta2/projects/',
-   *       'defaults' => ['auth' => 'scoped']
-   *   ]);
-   *   $client->getEmitter()->attach($subscriber);
-   *
-   *   $res = $client->get('myproject/taskqueues/myqueue');
-   */
-  public function onBefore(BeforeEvent $event)
-  {
-    // Requests using "auth"="scoped" will be authorized.
-    $request = $event->getRequest();
-    if ($request->getConfig()['auth'] != 'scoped') {
-      return;
-    }
-    $auth_header = 'Bearer ' . $this->fetchToken();
-    $request->setHeader('Authorization', $auth_header);
-  }
-
-  /**
-   * @return string
-   */
-  private function getCacheKey()
-  {
-    $key = null;
-
-    if (is_string($this->scopes)) {
-      $key .= $this->scopes;
-    } else if (is_array($this->scopes)) {
-      $key .= implode(":", $this->scopes);
-    }
-    return $key;
-  }
-
-  /**
-   * Determine if token is available in the cache, if not call tokenFunc to
-   * fetch it.
-   *
-   * @return string
-   */
-  private function fetchToken()
-  {
-    $cached = $this->getCachedValue();
-
-    if (!empty($cached)) {
-      return $cached;
+        if (!is_null($cache)) {
+            $this->cache = $cache;
+            $this->cacheConfig = array_merge([
+                'lifetime' => self::DEFAULT_CACHE_LIFETIME,
+                'prefix' => '',
+            ], $cacheConfig);
+        }
     }
 
-    $token = call_user_func($this->tokenFunc, $this->scopes);
-    $this->setCachedValue($token);
-    return $token;
-  }
+    /* Implements SubscriberInterface */
+    public function getEvents()
+    {
+        return ['before' => ['onBefore', RequestEvents::SIGN_REQUEST]];
+    }
+
+    /**
+     * Updates the request with an Authorization header when auth is 'scoped'.
+     *
+     *   E.g this could be used to authenticate using the AppEngine
+     *   AppIdentityService.
+     *
+     *   use google\appengine\api\app_identity\AppIdentityService;
+     *   use Google\Auth\Subscriber\ScopedAccessTokenSubscriber;
+     *   use GuzzleHttp\Client;
+     *
+     *   $scope = 'https://www.googleapis.com/auth/taskqueue'
+     *   $subscriber = new ScopedAccessToken(
+     *       'AppIdentityService::getAccessToken',
+     *       $scope,
+     *       ['prefix' => 'Google\Auth\ScopedAccessToken::'],
+     *       $cache = new Memcache()
+     *   );
+     *
+     *   $client = new Client([
+     *       'base_url' => 'https://www.googleapis.com/taskqueue/v1beta2/projects/',
+     *       'defaults' => ['auth' => 'scoped']
+     *   ]);
+     *   $client->getEmitter()->attach($subscriber);
+     *
+     *   $res = $client->get('myproject/taskqueues/myqueue');
+     */
+    public function onBefore(BeforeEvent $event)
+    {
+        // Requests using "auth"="scoped" will be authorized.
+        $request = $event->getRequest();
+        if ($request->getConfig()['auth'] != 'scoped') {
+            return;
+        }
+        $auth_header = 'Bearer '.$this->fetchToken();
+        $request->setHeader('Authorization', $auth_header);
+    }
+
+    /**
+     * @return string
+     */
+    private function getCacheKey()
+    {
+        $key = null;
+
+        if (is_string($this->scopes)) {
+            $key .= $this->scopes;
+        } elseif (is_array($this->scopes)) {
+            $key .= implode(':', $this->scopes);
+        }
+
+        return $key;
+    }
+
+    /**
+     * Determine if token is available in the cache, if not call tokenFunc to
+     * fetch it.
+     *
+     * @return string
+     */
+    private function fetchToken()
+    {
+        $cached = $this->getCachedValue();
+
+        if (!empty($cached)) {
+            return $cached;
+        }
+
+        $token = call_user_func($this->tokenFunc, $this->scopes);
+        $this->setCachedValue($token);
+
+        return $token;
+    }
 }

--- a/src/Subscriber/ScopedAccessTokenSubscriber.php
+++ b/src/Subscriber/ScopedAccessTokenSubscriber.php
@@ -41,16 +41,24 @@ class ScopedAccessTokenSubscriber implements SubscriberInterface
 
     const DEFAULT_CACHE_LIFETIME = 1500;
 
-    /** @var An implementation of CacheInterface */
+    /**
+     * @var CacheInterface
+     */
     private $cache;
 
-    /** @var The access token generator function */
+    /**
+     * @var callable The access token generator function
+     */
     private $tokenFunc;
 
-    /** @var The scopes used to generate the token */
+    /**
+     * @var array|string The scopes used to generate the token
+     */
     private $scopes;
 
-    /** @var cache configuration */
+    /**
+     * @var array
+     */
     private $cacheConfig;
 
     /**
@@ -83,7 +91,9 @@ class ScopedAccessTokenSubscriber implements SubscriberInterface
         }
     }
 
-    /* Implements SubscriberInterface */
+    /**
+     * @return array
+     */
     public function getEvents()
     {
         return ['before' => ['onBefore', RequestEvents::SIGN_REQUEST]];
@@ -114,6 +124,8 @@ class ScopedAccessTokenSubscriber implements SubscriberInterface
      *   $client->getEmitter()->attach($subscriber);
      *
      *   $res = $client->get('myproject/taskqueues/myqueue');
+     *
+     * @param BeforeEvent $event
      */
     public function onBefore(BeforeEvent $event)
     {

--- a/src/Subscriber/SimpleSubscriber.php
+++ b/src/Subscriber/SimpleSubscriber.php
@@ -29,7 +29,9 @@ use GuzzleHttp\Event\SubscriberInterface;
  */
 class SimpleSubscriber implements SubscriberInterface
 {
-    /** @var configuration */
+    /**
+     * @var array
+     */
     private $config;
 
     /**
@@ -49,7 +51,9 @@ class SimpleSubscriber implements SubscriberInterface
         $this->config = array_merge([], $config);
     }
 
-    /* Implements SubscriberInterface */
+    /**
+     * @return array
+     */
     public function getEvents()
     {
         return ['before' => ['onBefore', RequestEvents::SIGN_REQUEST]];
@@ -71,6 +75,8 @@ class SimpleSubscriber implements SubscriberInterface
      *   $client->getEmitter()->attach($subscriber);
      *
      *   $res = $client->get('drive/v2/rest');
+     *
+     * @param BeforeEvent $event
      */
     public function onBefore(BeforeEvent $event)
     {

--- a/src/Subscriber/SimpleSubscriber.php
+++ b/src/Subscriber/SimpleSubscriber.php
@@ -29,56 +29,56 @@ use GuzzleHttp\Event\SubscriberInterface;
  */
 class SimpleSubscriber implements SubscriberInterface
 {
-  /** @var configuration */
-  private $config;
+    /** @var configuration */
+    private $config;
 
-  /**
-   * Create a new Simple plugin.
-   *
-   * The configuration array expects one option
-   * - key: required, otherwise InvalidArgumentException is thrown
-   *
-   * @param array $config Configuration array
-   */
-  public function __construct(array $config)
-  {
-    if (!isset($config['key'])) {
-      throw new \InvalidArgumentException('requires a key to have been set');
+    /**
+     * Create a new Simple plugin.
+     *
+     * The configuration array expects one option
+     * - key: required, otherwise InvalidArgumentException is thrown
+     *
+     * @param array $config Configuration array
+     */
+    public function __construct(array $config)
+    {
+        if (!isset($config['key'])) {
+            throw new \InvalidArgumentException('requires a key to have been set');
+        }
+
+        $this->config = array_merge([], $config);
     }
 
-    $this->config = array_merge([], $config);
-  }
-
-  /* Implements SubscriberInterface */
-  public function getEvents()
-  {
-    return ['before' => ['onBefore', RequestEvents::SIGN_REQUEST]];
-  }
-
-  /**
-   * Updates the request query with the developer key if auth is set to simple
-   *
-   *   use Google\Auth\Subscriber\SimpleSubscriber;
-   *   use GuzzleHttp\Client;
-   *
-   *   $my_key = 'is not the same as yours';
-   *   $subscriber = new SimpleSubscriber(['key' => $my_key]);
-   *
-   *   $client = new Client([
-   *      'base_url' => 'https://www.googleapis.com/discovery/v1/',
-   *      'defaults' => ['auth' => 'simple']
-   *   ]);
-   *   $client->getEmitter()->attach($subscriber);
-   *
-   *   $res = $client->get('drive/v2/rest');
-   */
-  public function onBefore(BeforeEvent $event)
-  {
-    // Requests using "auth"="simple" with the developer key.
-    $request = $event->getRequest();
-    if ($request->getConfig()['auth'] != 'simple') {
-      return;
+    /* Implements SubscriberInterface */
+    public function getEvents()
+    {
+        return ['before' => ['onBefore', RequestEvents::SIGN_REQUEST]];
     }
-    $request->getQuery()->overwriteWith($this->config);
-  }
+
+    /**
+     * Updates the request query with the developer key if auth is set to simple.
+     *
+     *   use Google\Auth\Subscriber\SimpleSubscriber;
+     *   use GuzzleHttp\Client;
+     *
+     *   $my_key = 'is not the same as yours';
+     *   $subscriber = new SimpleSubscriber(['key' => $my_key]);
+     *
+     *   $client = new Client([
+     *      'base_url' => 'https://www.googleapis.com/discovery/v1/',
+     *      'defaults' => ['auth' => 'simple']
+     *   ]);
+     *   $client->getEmitter()->attach($subscriber);
+     *
+     *   $res = $client->get('drive/v2/rest');
+     */
+    public function onBefore(BeforeEvent $event)
+    {
+        // Requests using "auth"="simple" with the developer key.
+        $request = $event->getRequest();
+        if ($request->getConfig()['auth'] != 'simple') {
+            return;
+        }
+        $request->getQuery()->overwriteWith($this->config);
+    }
 }

--- a/tests/ApplicationDefaultCredentialsTest.php
+++ b/tests/ApplicationDefaultCredentialsTest.php
@@ -24,232 +24,230 @@ use GuzzleHttp\Psr7;
 
 class ADCGetTest extends \PHPUnit_Framework_TestCase
 {
-  private $originalHome;
+    private $originalHome;
 
-  protected function setUp()
-  {
-    $this->originalHome = getenv('HOME');
-  }
-
-  protected function tearDown()
-  {
-    if ($this->originalHome != getenv('HOME')) {
-      putenv('HOME=' . $this->originalHome);
+    protected function setUp()
+    {
+        $this->originalHome = getenv('HOME');
     }
-    putenv(ServiceAccountCredentials::ENV_VAR);  // removes it from
-  }
 
-  /**
-   * @expectedException DomainException
-   */
-  public function testIsFailsEnvSpecifiesNonExistentFile()
-  {
-    $keyFile = __DIR__ . '/fixtures' . '/does-not-exist-private.json';
-    putenv(ServiceAccountCredentials::ENV_VAR . '=' . $keyFile);
-    ApplicationDefaultCredentials::getCredentials('a scope');
-  }
+    protected function tearDown()
+    {
+        if ($this->originalHome != getenv('HOME')) {
+            putenv('HOME='.$this->originalHome);
+        }
+        putenv(ServiceAccountCredentials::ENV_VAR);  // removes it from
+    }
 
-  public function testLoadsOKIfEnvSpecifiedIsValid()
-  {
-    $keyFile = __DIR__ . '/fixtures' . '/private.json';
-    putenv(ServiceAccountCredentials::ENV_VAR . '=' . $keyFile);
-    $this->assertNotNull(
-        ApplicationDefaultCredentials::getCredentials('a scope')
-    );
-  }
+    /**
+     * @expectedException DomainException
+     */
+    public function testIsFailsEnvSpecifiesNonExistentFile()
+    {
+        $keyFile = __DIR__.'/fixtures'.'/does-not-exist-private.json';
+        putenv(ServiceAccountCredentials::ENV_VAR.'='.$keyFile);
+        ApplicationDefaultCredentials::getCredentials('a scope');
+    }
 
-  public function testLoadsDefaultFileIfPresentAndEnvVarIsNotSet()
-  {
-    putenv('HOME=' . __DIR__ . '/fixtures');
-    $this->assertNotNull(
-        ApplicationDefaultCredentials::getCredentials('a scope')
-    );
-  }
+    public function testLoadsOKIfEnvSpecifiedIsValid()
+    {
+        $keyFile = __DIR__.'/fixtures'.'/private.json';
+        putenv(ServiceAccountCredentials::ENV_VAR.'='.$keyFile);
+        $this->assertNotNull(
+            ApplicationDefaultCredentials::getCredentials('a scope')
+        );
+    }
 
-  /**
-   * @expectedException DomainException
-   */
-  public function testFailsIfNotOnGceAndNoDefaultFileFound()
-  {
-    putenv('HOME=' . __DIR__ . '/not_exist_fixtures');
-    // simulate not being GCE by return 500
-    $httpHandler = getHandler([
-      buildResponse(500)
-    ]);
+    public function testLoadsDefaultFileIfPresentAndEnvVarIsNotSet()
+    {
+        putenv('HOME='.__DIR__.'/fixtures');
+        $this->assertNotNull(
+            ApplicationDefaultCredentials::getCredentials('a scope')
+        );
+    }
 
-    ApplicationDefaultCredentials::getCredentials('a scope', $httpHandler);
-  }
+    /**
+     * @expectedException DomainException
+     */
+    public function testFailsIfNotOnGceAndNoDefaultFileFound()
+    {
+        putenv('HOME='.__DIR__.'/not_exist_fixtures');
+        // simulate not being GCE by return 500
+        $httpHandler = getHandler([
+            buildResponse(500),
+        ]);
 
-  public function testSuccedsIfNoDefaultFilesButIsOnGCE()
-  {
-    $wantedTokens = [
-        'access_token' => '1/abdef1234567890',
-        'expires_in' => '57',
-        'token_type' => 'Bearer',
-    ];
-    $jsonTokens = json_encode($wantedTokens);
+        ApplicationDefaultCredentials::getCredentials('a scope', $httpHandler);
+    }
 
-    // simulate the response from GCE.
-    $httpHandler = getHandler([
-      buildResponse(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
-      buildResponse(200, [], Psr7\stream_for($jsonTokens))
-    ]);
+    public function testSuccedsIfNoDefaultFilesButIsOnGCE()
+    {
+        $wantedTokens = [
+            'access_token' => '1/abdef1234567890',
+            'expires_in' => '57',
+            'token_type' => 'Bearer',
+        ];
+        $jsonTokens = json_encode($wantedTokens);
 
-    $this->assertNotNull(
-        ApplicationDefaultCredentials::getCredentials('a scope', $httpHandler)
-    );
-  }
+        // simulate the response from GCE.
+        $httpHandler = getHandler([
+            buildResponse(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
+            buildResponse(200, [], Psr7\stream_for($jsonTokens)),
+        ]);
+
+        $this->assertNotNull(
+            ApplicationDefaultCredentials::getCredentials('a scope', $httpHandler)
+        );
+    }
 }
 
 class ADCGetMiddlewareTest extends \PHPUnit_Framework_TestCase
 {
-  private $originalHome;
+    private $originalHome;
 
-  protected function setUp()
-  {
-    $this->originalHome = getenv('HOME');
-  }
-
-  protected function tearDown()
-  {
-    if ($this->originalHome != getenv('HOME')) {
-      putenv('HOME=' . $this->originalHome);
+    protected function setUp()
+    {
+        $this->originalHome = getenv('HOME');
     }
-    putenv(ServiceAccountCredentials::ENV_VAR);  // removes it if assigned
-  }
 
-  /**
-   * @expectedException DomainException
-   */
-  public function testIsFailsEnvSpecifiesNonExistentFile()
-  {
-    $keyFile = __DIR__ . '/fixtures' . '/does-not-exist-private.json';
-    putenv(ServiceAccountCredentials::ENV_VAR . '=' . $keyFile);
-    ApplicationDefaultCredentials::getMiddleware('a scope');
-  }
+    protected function tearDown()
+    {
+        if ($this->originalHome != getenv('HOME')) {
+            putenv('HOME='.$this->originalHome);
+        }
+        putenv(ServiceAccountCredentials::ENV_VAR);  // removes it if assigned
+    }
 
-  public function testLoadsOKIfEnvSpecifiedIsValid()
-  {
-    $keyFile = __DIR__ . '/fixtures' . '/private.json';
-    putenv(ServiceAccountCredentials::ENV_VAR . '=' . $keyFile);
-    $this->assertNotNull(ApplicationDefaultCredentials::getMiddleware('a scope'));
-  }
+    /**
+     * @expectedException DomainException
+     */
+    public function testIsFailsEnvSpecifiesNonExistentFile()
+    {
+        $keyFile = __DIR__.'/fixtures'.'/does-not-exist-private.json';
+        putenv(ServiceAccountCredentials::ENV_VAR.'='.$keyFile);
+        ApplicationDefaultCredentials::getMiddleware('a scope');
+    }
 
-  public function testLoadsDefaultFileIfPresentAndEnvVarIsNotSet()
-  {
-    putenv('HOME=' . __DIR__ . '/fixtures');
-    $this->assertNotNull(ApplicationDefaultCredentials::getMiddleware('a scope'));
+    public function testLoadsOKIfEnvSpecifiedIsValid()
+    {
+        $keyFile = __DIR__.'/fixtures'.'/private.json';
+        putenv(ServiceAccountCredentials::ENV_VAR.'='.$keyFile);
+        $this->assertNotNull(ApplicationDefaultCredentials::getMiddleware('a scope'));
+    }
 
-  }
+    public function testLoadsDefaultFileIfPresentAndEnvVarIsNotSet()
+    {
+        putenv('HOME='.__DIR__.'/fixtures');
+        $this->assertNotNull(ApplicationDefaultCredentials::getMiddleware('a scope'));
+    }
 
-  /**
-   * @expectedException DomainException
-   */
-  public function testFailsIfNotOnGceAndNoDefaultFileFound()
-  {
-    putenv('HOME=' . __DIR__ . '/not_exist_fixtures');
+    /**
+     * @expectedException DomainException
+     */
+    public function testFailsIfNotOnGceAndNoDefaultFileFound()
+    {
+        putenv('HOME='.__DIR__.'/not_exist_fixtures');
 
-    // simulate not being GCE by return 500
-    $httpHandler = getHandler([
-      buildResponse(500)
-    ]);
+        // simulate not being GCE by return 500
+        $httpHandler = getHandler([
+            buildResponse(500),
+        ]);
 
-    ApplicationDefaultCredentials::getMiddleware('a scope', $httpHandler);
-  }
+        ApplicationDefaultCredentials::getMiddleware('a scope', $httpHandler);
+    }
 
-  public function testSuccedsIfNoDefaultFilesButIsOnGCE()
-  {
-    $wantedTokens = [
-        'access_token' => '1/abdef1234567890',
-        'expires_in' => '57',
-        'token_type' => 'Bearer',
-    ];
-    $jsonTokens = json_encode($wantedTokens);
+    public function testSuccedsIfNoDefaultFilesButIsOnGCE()
+    {
+        $wantedTokens = [
+            'access_token' => '1/abdef1234567890',
+            'expires_in' => '57',
+            'token_type' => 'Bearer',
+        ];
+        $jsonTokens = json_encode($wantedTokens);
 
-    // simulate the response from GCE.
-    $httpHandler = getHandler([
-      buildResponse(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
-      buildResponse(200, [], Psr7\stream_for($jsonTokens))
-    ]);
+        // simulate the response from GCE.
+        $httpHandler = getHandler([
+            buildResponse(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
+            buildResponse(200, [], Psr7\stream_for($jsonTokens)),
+        ]);
 
-    $this->assertNotNull(ApplicationDefaultCredentials::getMiddleware('a scope', $httpHandler));
-  }
+        $this->assertNotNull(ApplicationDefaultCredentials::getMiddleware('a scope', $httpHandler));
+    }
 }
 
 // @todo consider a way to DRY this and above class up
 class ADCGetSubscriberTest extends BaseTest
 {
-  private $originalHome;
+    private $originalHome;
 
-  protected function setUp()
-  {
-    $this->onlyGuzzle5();
+    protected function setUp()
+    {
+        $this->onlyGuzzle5();
 
-    $this->originalHome = getenv('HOME');
-  }
-
-  protected function tearDown()
-  {
-    if ($this->originalHome != getenv('HOME')) {
-      putenv('HOME=' . $this->originalHome);
+        $this->originalHome = getenv('HOME');
     }
-    putenv(ServiceAccountCredentials::ENV_VAR);  // removes it if assigned
-  }
 
-  /**
-   * @expectedException DomainException
-   */
-  public function testIsFailsEnvSpecifiesNonExistentFile()
-  {
-    $keyFile = __DIR__ . '/fixtures' . '/does-not-exist-private.json';
-    putenv(ServiceAccountCredentials::ENV_VAR . '=' . $keyFile);
-    ApplicationDefaultCredentials::getSubscriber('a scope');
-  }
+    protected function tearDown()
+    {
+        if ($this->originalHome != getenv('HOME')) {
+            putenv('HOME='.$this->originalHome);
+        }
+        putenv(ServiceAccountCredentials::ENV_VAR);  // removes it if assigned
+    }
 
-  public function testLoadsOKIfEnvSpecifiedIsValid()
-  {
-    $keyFile = __DIR__ . '/fixtures' . '/private.json';
-    putenv(ServiceAccountCredentials::ENV_VAR . '=' . $keyFile);
-    $this->assertNotNull(ApplicationDefaultCredentials::getSubscriber('a scope'));
-  }
+    /**
+     * @expectedException DomainException
+     */
+    public function testIsFailsEnvSpecifiesNonExistentFile()
+    {
+        $keyFile = __DIR__.'/fixtures'.'/does-not-exist-private.json';
+        putenv(ServiceAccountCredentials::ENV_VAR.'='.$keyFile);
+        ApplicationDefaultCredentials::getSubscriber('a scope');
+    }
 
-  public function testLoadsDefaultFileIfPresentAndEnvVarIsNotSet()
-  {
-    putenv('HOME=' . __DIR__ . '/fixtures');
-    $this->assertNotNull(ApplicationDefaultCredentials::getSubscriber('a scope'));
+    public function testLoadsOKIfEnvSpecifiedIsValid()
+    {
+        $keyFile = __DIR__.'/fixtures'.'/private.json';
+        putenv(ServiceAccountCredentials::ENV_VAR.'='.$keyFile);
+        $this->assertNotNull(ApplicationDefaultCredentials::getSubscriber('a scope'));
+    }
 
-  }
+    public function testLoadsDefaultFileIfPresentAndEnvVarIsNotSet()
+    {
+        putenv('HOME='.__DIR__.'/fixtures');
+        $this->assertNotNull(ApplicationDefaultCredentials::getSubscriber('a scope'));
+    }
 
-  /**
-   * @expectedException DomainException
-   */
-  public function testFailsIfNotOnGceAndNoDefaultFileFound()
-  {
-    putenv('HOME=' . __DIR__ . '/not_exist_fixtures');
+    /**
+     * @expectedException DomainException
+     */
+    public function testFailsIfNotOnGceAndNoDefaultFileFound()
+    {
+        putenv('HOME='.__DIR__.'/not_exist_fixtures');
 
-    // simulate not being GCE by return 500
-    $httpHandler = getHandler([
-      buildResponse(500)
-    ]);
+        // simulate not being GCE by return 500
+        $httpHandler = getHandler([
+            buildResponse(500),
+        ]);
 
-    ApplicationDefaultCredentials::getSubscriber('a scope', $httpHandler);
-  }
+        ApplicationDefaultCredentials::getSubscriber('a scope', $httpHandler);
+    }
 
-  public function testSuccedsIfNoDefaultFilesButIsOnGCE()
-  {
-    $wantedTokens = [
-        'access_token' => '1/abdef1234567890',
-        'expires_in' => '57',
-        'token_type' => 'Bearer',
-    ];
-    $jsonTokens = json_encode($wantedTokens);
+    public function testSuccedsIfNoDefaultFilesButIsOnGCE()
+    {
+        $wantedTokens = [
+            'access_token' => '1/abdef1234567890',
+            'expires_in' => '57',
+            'token_type' => 'Bearer',
+        ];
+        $jsonTokens = json_encode($wantedTokens);
 
-    // simulate the response from GCE.
-    $httpHandler = getHandler([
-      buildResponse(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
-      buildResponse(200, [], Psr7\stream_for($jsonTokens))
-    ]);
+        // simulate the response from GCE.
+        $httpHandler = getHandler([
+            buildResponse(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
+            buildResponse(200, [], Psr7\stream_for($jsonTokens)),
+        ]);
 
-    $this->assertNotNull(ApplicationDefaultCredentials::getSubscriber('a scope', $httpHandler));
-  }
+        $this->assertNotNull(ApplicationDefaultCredentials::getSubscriber('a scope', $httpHandler));
+    }
 }

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -1,24 +1,24 @@
 <?php
 
-namespace Google\Auth\Tests;
+namespace Google\Auth\tests;
 
 use GuzzleHttp\ClientInterface;
 
 abstract class BaseTest extends \PHPUnit_Framework_TestCase
 {
-  public function onlyGuzzle6()
-  {
-    $version = ClientInterface::VERSION;
-    if ('6' !== $version[0]) {
-      $this->markTestSkipped('Guzzle 6 only');
+    public function onlyGuzzle6()
+    {
+        $version = ClientInterface::VERSION;
+        if ('6' !== $version[0]) {
+            $this->markTestSkipped('Guzzle 6 only');
+        }
     }
-  }
 
-  public function onlyGuzzle5()
-  {
-    $version = ClientInterface::VERSION;
-    if ('5' !== $version[0]) {
-      $this->markTestSkipped('Guzzle 5 only');
+    public function onlyGuzzle5()
+    {
+        $version = ClientInterface::VERSION;
+        if ('5' !== $version[0]) {
+            $this->markTestSkipped('Guzzle 5 only');
+        }
     }
-  }
 }

--- a/tests/CacheTraitTest.php
+++ b/tests/CacheTraitTest.php
@@ -21,176 +21,176 @@ use Google\Auth\CacheTrait;
 
 class CacheTraitTest extends \PHPUnit_Framework_TestCase
 {
-  private $mockFetcher;
-  private $mockCache;
+    private $mockFetcher;
+    private $mockCache;
 
-  public function setUp()
-  {
-    $this->mockFetcher =
-      $this
-      ->getMockBuilder('Google\Auth\FetchAuthTokenInterface')
-      ->getMock();
-    $this->mockCache =
-      $this
-      ->getMockBuilder('Google\Auth\CacheInterface')
-      ->getMock();
-  }
+    public function setUp()
+    {
+        $this->mockFetcher =
+            $this
+                ->getMockBuilder('Google\Auth\FetchAuthTokenInterface')
+                ->getMock();
+        $this->mockCache =
+            $this
+                ->getMockBuilder('Google\Auth\CacheInterface')
+                ->getMock();
+    }
 
-  public function testSuccessfullyPullsFromCacheWithoutFetcher()
-  {
-    $expectedValue = '1234';
-    $this->mockCache
-      ->expects($this->once())
-      ->method('get')
-      ->will($this->returnValue($expectedValue));
+    public function testSuccessfullyPullsFromCacheWithoutFetcher()
+    {
+        $expectedValue = '1234';
+        $this->mockCache
+            ->expects($this->once())
+            ->method('get')
+            ->will($this->returnValue($expectedValue));
 
-    $implementation = new CacheTraitImplementation([
-      'cache' => $this->mockCache
-    ]);
+        $implementation = new CacheTraitImplementation([
+            'cache' => $this->mockCache,
+        ]);
 
-    $cachedValue = $implementation->gCachedValue();
-    $this->assertEquals($expectedValue, $cachedValue);
-  }
+        $cachedValue = $implementation->gCachedValue();
+        $this->assertEquals($expectedValue, $cachedValue);
+    }
 
-  public function testSuccessfullyPullsFromCacheWithFetcher()
-  {
-    $expectedValue = '1234';
-    $this->mockCache
-      ->expects($this->once())
-      ->method('get')
-      ->will($this->returnValue($expectedValue));
-    $this->mockFetcher
-      ->expects($this->once())
-      ->method('getCacheKey')
-      ->will($this->returnValue('key'));
+    public function testSuccessfullyPullsFromCacheWithFetcher()
+    {
+        $expectedValue = '1234';
+        $this->mockCache
+            ->expects($this->once())
+            ->method('get')
+            ->will($this->returnValue($expectedValue));
+        $this->mockFetcher
+            ->expects($this->once())
+            ->method('getCacheKey')
+            ->will($this->returnValue('key'));
 
-    $implementation = new CacheTraitImplementation([
-      'cache' => $this->mockCache,
-      'fetcher' => $this->mockFetcher
-    ]);
+        $implementation = new CacheTraitImplementation([
+            'cache' => $this->mockCache,
+            'fetcher' => $this->mockFetcher,
+        ]);
 
-    $cachedValue = $implementation->gCachedValue();
-    $this->assertEquals($expectedValue, $cachedValue);
-  }
+        $cachedValue = $implementation->gCachedValue();
+        $this->assertEquals($expectedValue, $cachedValue);
+    }
 
-  public function testFailsPullFromCacheWithNoCache()
-  {
-    $implementation = new CacheTraitImplementation();
+    public function testFailsPullFromCacheWithNoCache()
+    {
+        $implementation = new CacheTraitImplementation();
 
-    $cachedValue = $implementation->gCachedValue();
-    $this->assertEquals(null, $cachedValue);
-  }
+        $cachedValue = $implementation->gCachedValue();
+        $this->assertEquals(null, $cachedValue);
+    }
 
-  public function testFailsPullFromCacheWithoutKey()
-  {
-    $this->mockFetcher
-      ->expects($this->once())
-      ->method('getCacheKey')
-      ->will($this->returnValue(null));
+    public function testFailsPullFromCacheWithoutKey()
+    {
+        $this->mockFetcher
+            ->expects($this->once())
+            ->method('getCacheKey')
+            ->will($this->returnValue(null));
 
-    $implementation = new CacheTraitImplementation([
-      'cache' => $this->mockCache,
-      'fetcher' => $this->mockFetcher
-    ]);
+        $implementation = new CacheTraitImplementation([
+            'cache' => $this->mockCache,
+            'fetcher' => $this->mockFetcher,
+        ]);
 
-    $cachedValue = $implementation->gCachedValue();
-  }
+        $cachedValue = $implementation->gCachedValue();
+    }
 
-  public function testSuccessfullySetsToCacheWithoutFetcher()
-  {
-    $value = '1234';
-    $this->mockCache
-      ->expects($this->once())
-      ->method('set')
-      ->with('key', $value);
+    public function testSuccessfullySetsToCacheWithoutFetcher()
+    {
+        $value = '1234';
+        $this->mockCache
+            ->expects($this->once())
+            ->method('set')
+            ->with('key', $value);
 
-    $implementation = new CacheTraitImplementation([
-      'cache' => $this->mockCache
-    ]);
+        $implementation = new CacheTraitImplementation([
+            'cache' => $this->mockCache,
+        ]);
 
-    $implementation->sCachedValue($value);
-  }
+        $implementation->sCachedValue($value);
+    }
 
-  public function testSuccessfullySetsToCacheWithFetcher()
-  {
-    $value = '1234';
-    $this->mockCache
-      ->expects($this->once())
-      ->method('set')
-      ->with('key', $value);
-    $this->mockFetcher
-      ->expects($this->once())
-      ->method('getCacheKey')
-      ->will($this->returnValue('key'));
+    public function testSuccessfullySetsToCacheWithFetcher()
+    {
+        $value = '1234';
+        $this->mockCache
+            ->expects($this->once())
+            ->method('set')
+            ->with('key', $value);
+        $this->mockFetcher
+            ->expects($this->once())
+            ->method('getCacheKey')
+            ->will($this->returnValue('key'));
 
-    $implementation = new CacheTraitImplementation([
-      'cache' => $this->mockCache,
-      'fetcher' => $this->mockFetcher
-    ]);
+        $implementation = new CacheTraitImplementation([
+            'cache' => $this->mockCache,
+            'fetcher' => $this->mockFetcher,
+        ]);
 
-    $implementation->sCachedValue($value);
-  }
+        $implementation->sCachedValue($value);
+    }
 
-  public function testFailsSetToCacheWithNoCache()
-  {
-    $this->mockFetcher
-      ->expects($this->never())
-      ->method('getCacheKey');
+    public function testFailsSetToCacheWithNoCache()
+    {
+        $this->mockFetcher
+            ->expects($this->never())
+            ->method('getCacheKey');
 
-    $implementation = new CacheTraitImplementation([
-      'fetcher' => $this->mockFetcher
-    ]);
+        $implementation = new CacheTraitImplementation([
+            'fetcher' => $this->mockFetcher,
+        ]);
 
-    $implementation->sCachedValue('1234');
-  }
+        $implementation->sCachedValue('1234');
+    }
 
-  public function testFailsSetToCacheWithoutKey()
-  {
-    $this->mockFetcher
-      ->expects($this->once())
-      ->method('getCacheKey')
-      ->will($this->returnValue(null));
+    public function testFailsSetToCacheWithoutKey()
+    {
+        $this->mockFetcher
+            ->expects($this->once())
+            ->method('getCacheKey')
+            ->will($this->returnValue(null));
 
-    $implementation = new CacheTraitImplementation([
-      'cache' => $this->mockCache,
-      'fetcher' => $this->mockFetcher
-    ]);
+        $implementation = new CacheTraitImplementation([
+            'cache' => $this->mockCache,
+            'fetcher' => $this->mockFetcher,
+        ]);
 
-    $cachedValue = $implementation->sCachedValue('1234');
-  }
+        $cachedValue = $implementation->sCachedValue('1234');
+    }
 }
 
 class CacheTraitImplementation
 {
-  use CacheTrait;
+    use CacheTrait;
 
-  private $cache;
-  private $fetcher;
-  private $cacheConfig;
+    private $cache;
+    private $fetcher;
+    private $cacheConfig;
 
-  public function __construct(array $config = [])
-  {
-    $this->cache = isset($config['cache']) ? $config['cache'] : null;
-    $this->fetcher = isset($config['fetcher']) ? $config['fetcher'] : null;
-    $this->cacheConfig = [
-      'prefix' => '',
-      'lifetime' => 1000
-    ];
-  }
+    public function __construct(array $config = [])
+    {
+        $this->cache = isset($config['cache']) ? $config['cache'] : null;
+        $this->fetcher = isset($config['fetcher']) ? $config['fetcher'] : null;
+        $this->cacheConfig = [
+            'prefix' => '',
+            'lifetime' => 1000,
+        ];
+    }
 
-  // allows us to keep trait methods private
-  public function gCachedValue()
-  {
-    return $this->getCachedValue();
-  }
+    // allows us to keep trait methods private
+    public function gCachedValue()
+    {
+        return $this->getCachedValue();
+    }
 
-  public function sCachedValue($v)
-  {
-    $this->setCachedValue($v);
-  }
+    public function sCachedValue($v)
+    {
+        $this->setCachedValue($v);
+    }
 
-  private function getCacheKey()
-  {
-    return 'key';
-  }
+    private function getCacheKey()
+    {
+        return 'key';
+    }
 }

--- a/tests/Credentials/AppIndentityCredentialsTest.php
+++ b/tests/Credentials/AppIndentityCredentialsTest.php
@@ -17,90 +17,88 @@
 
 namespace Google\Auth\Tests;
 
-use Google\Auth\Credentials\AppIdentityCredentials;
-use GuzzleHttp\Psr7\Response;
-
-// included from tests\mocks\AppIdentityService.php
 use google\appengine\api\app_identity\AppIdentityService;
+// included from tests\mocks\AppIdentityService.php
+use Google\Auth\Credentials\AppIdentityCredentials;
 
 class AppIdentityCredentialsOnAppEngineTest extends \PHPUnit_Framework_TestCase
 {
-  public function testIsFalseByDefault()
-  {
-    $this->assertFalse(AppIdentityCredentials::onAppEngine());
-  }
+    public function testIsFalseByDefault()
+    {
+        $this->assertFalse(AppIdentityCredentials::onAppEngine());
+    }
 
-  public function testIsTrueWhenServerSoftwareIsGoogleAppEngine()
-  {
-    $_SERVER['SERVER_SOFTWARE'] = 'Google App Engine';
-    $this->assertTrue(AppIdentityCredentials::onAppEngine());
-  }
+    public function testIsTrueWhenServerSoftwareIsGoogleAppEngine()
+    {
+        $_SERVER['SERVER_SOFTWARE'] = 'Google App Engine';
+        $this->assertTrue(AppIdentityCredentials::onAppEngine());
+    }
 }
 
 class AppIdentityCredentialsGetCacheKeyTest extends \PHPUnit_Framework_TestCase
 {
-  public function testShouldNotBeEmpty()
-  {
-    $g = new AppIdentityCredentials();
-    $this->assertNotEmpty($g->getCacheKey());
-  }
+    public function testShouldNotBeEmpty()
+    {
+        $g = new AppIdentityCredentials();
+        $this->assertNotEmpty($g->getCacheKey());
+    }
 }
 
 class AppIdentityCredentialsFetchAuthTokenTest extends \PHPUnit_Framework_TestCase
 {
-  public function testShouldBeEmptyIfNotOnAppEngine()
-  {
-    $g = new AppIdentityCredentials();
-    $this->assertEquals(array(), $g->fetchAuthToken());
-  }
+    public function testShouldBeEmptyIfNotOnAppEngine()
+    {
+        $g = new AppIdentityCredentials();
+        $this->assertEquals(array(), $g->fetchAuthToken());
+    }
 
-  /* @expectedException */
-  public function testThrowsExceptionIfClassDoesntExist()
-  {
-    $_SERVER['SERVER_SOFTWARE'] = 'Google App Engine';
-    $g = new AppIdentityCredentials();
-  }
+    /* @expectedException */
+    public function testThrowsExceptionIfClassDoesntExist()
+    {
+        $_SERVER['SERVER_SOFTWARE'] = 'Google App Engine';
+        $g = new AppIdentityCredentials();
+    }
 
-  public function testReturnsExpectedToken()
-  {
-    // include the mock AppIdentityService class
-    require_once __DIR__ . '/../mocks/AppIdentityService.php';
+    public function testReturnsExpectedToken()
+    {
+        // include the mock AppIdentityService class
+        require_once __DIR__.'/../mocks/AppIdentityService.php';
 
-    $wantedToken = [
-        'access_token' => '1/abdef1234567890',
-        'expires_in' => '57',
-        'token_type' => 'Bearer',
-    ];
+        $wantedToken = [
+            'access_token' => '1/abdef1234567890',
+            'expires_in' => '57',
+            'token_type' => 'Bearer',
+        ];
 
-    AppIdentityService::$accessToken = $wantedToken;
+        AppIdentityService::$accessToken = $wantedToken;
 
-    $_SERVER['SERVER_SOFTWARE'] = 'Google App Engine';
+        $_SERVER['SERVER_SOFTWARE'] = 'Google App Engine';
 
-    $g = new AppIdentityCredentials();
-    $this->assertEquals($wantedToken, $g->fetchAuthToken());
-  }
+        $g = new AppIdentityCredentials();
+        $this->assertEquals($wantedToken, $g->fetchAuthToken());
+    }
 
-  public function testScopeIsAlwaysArray()
-  {
-    // include the mock AppIdentityService class
-    require_once __DIR__ . '/../mocks/AppIdentityService.php';
+    public function testScopeIsAlwaysArray()
+    {
+        // include the mock AppIdentityService class
+        require_once __DIR__.'/../mocks/AppIdentityService.php';
 
-    $scope1 = ['scopeA', 'scopeB'];
-    $scope2 = 'scopeA scopeB';
-    $scope3 = 'scopeA';
+        $scope1 = ['scopeA', 'scopeB'];
+        $scope2 = 'scopeA scopeB';
+        $scope3 = 'scopeA';
 
-    $_SERVER['SERVER_SOFTWARE'] = 'Google App Engine';
+        $_SERVER['SERVER_SOFTWARE'] = 'Google App Engine';
 
-    $g = new AppIdentityCredentials($scope1);
-    $g->fetchAuthToken();
-    $this->assertEquals($scope1, AppIdentityService::$scope);
+        $g = new AppIdentityCredentials($scope1);
+        $g->fetchAuthToken();
+        $this->assertEquals($scope1, AppIdentityService::$scope);
 
-    $g = new AppIdentityCredentials($scope2);
-    $g->fetchAuthToken();
-    $this->assertEquals(explode(' ', $scope2), AppIdentityService::$scope);
+        $g = new AppIdentityCredentials($scope2);
+        $g->fetchAuthToken();
+        $this->assertEquals(explode(' ', $scope2), AppIdentityService::$scope);
 
-    $g = new AppIdentityCredentials($scope3);
-    $g->fetchAuthToken();
-    $this->assertEquals([$scope3], AppIdentityService::$scope);
-  }
+        $g = new AppIdentityCredentials($scope3);
+        $g->fetchAuthToken();
+        $this->assertEquals([$scope3], AppIdentityService::$scope);
+    }
 }

--- a/tests/Credentials/GCECredentialsTest.php
+++ b/tests/Credentials/GCECredentialsTest.php
@@ -18,95 +18,93 @@
 namespace Google\Auth\Tests;
 
 use Google\Auth\Credentials\GCECredentials;
-use Google\Auth\HttpHandler\Guzzle6HttpHandler;
-use GuzzleHttp\Client;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Response;
 
 class GCECredentialsOnGCETest extends \PHPUnit_Framework_TestCase
 {
-  public function testIsFalseOnClientErrorStatus()
-  {
-    $httpHandler = getHandler([
-      buildResponse(400)
-    ]);
-    $this->assertFalse(GCECredentials::onGCE($httpHandler));
-  }
+    public function testIsFalseOnClientErrorStatus()
+    {
+        $httpHandler = getHandler([
+            buildResponse(400),
+        ]);
+        $this->assertFalse(GCECredentials::onGCE($httpHandler));
+    }
 
-  public function testIsFalseOnServerErrorStatus()
-  {
-    $httpHandler = getHandler([
-      buildResponse(500)
-    ]);
-    $this->assertFalse(GCECredentials::onGCE($httpHandler));
-  }
+    public function testIsFalseOnServerErrorStatus()
+    {
+        $httpHandler = getHandler([
+            buildResponse(500),
+        ]);
+        $this->assertFalse(GCECredentials::onGCE($httpHandler));
+    }
 
-  public function testIsFalseOnOkStatusWithoutExpectedHeader()
-  {
-    $httpHandler = getHandler([
-      buildResponse(200)
-    ]);
-    $this->assertFalse(GCECredentials::onGCE($httpHandler));
-  }
+    public function testIsFalseOnOkStatusWithoutExpectedHeader()
+    {
+        $httpHandler = getHandler([
+            buildResponse(200),
+        ]);
+        $this->assertFalse(GCECredentials::onGCE($httpHandler));
+    }
 
-  public function testIsOkIfGoogleIsTheFlavor()
-  {
-    $httpHandler = getHandler([
-      buildResponse(200, [GCECredentials::FLAVOR_HEADER => 'Google'])
-    ]);
-    $this->assertTrue(GCECredentials::onGCE($httpHandler));
-  }
+    public function testIsOkIfGoogleIsTheFlavor()
+    {
+        $httpHandler = getHandler([
+            buildResponse(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
+        ]);
+        $this->assertTrue(GCECredentials::onGCE($httpHandler));
+    }
 }
 
 class GCECredentialsGetCacheKeyTest extends \PHPUnit_Framework_TestCase
 {
-  public function testShouldNotBeEmpty()
-  {
-    $g = new GCECredentials();
-    $this->assertNotEmpty($g->getCacheKey());
-  }
+    public function testShouldNotBeEmpty()
+    {
+        $g = new GCECredentials();
+        $this->assertNotEmpty($g->getCacheKey());
+    }
 }
 
 class GCECredentialsFetchAuthTokenTest extends \PHPUnit_Framework_TestCase
 {
-  public function testShouldBeEmptyIfNotOnGCE()
-  {
-    $httpHandler = getHandler([
-      buildResponse(500)
-    ]);
-    $g = new GCECredentials();
-    $this->assertEquals(array(), $g->fetchAuthToken($httpHandler));
-  }
+    public function testShouldBeEmptyIfNotOnGCE()
+    {
+        $httpHandler = getHandler([
+            buildResponse(500),
+        ]);
+        $g = new GCECredentials();
+        $this->assertEquals(array(), $g->fetchAuthToken($httpHandler));
+    }
 
-  /**
-   * @expectedException Exception
-   * @expectedExceptionMessage Invalid JSON response
-   */
-  public function testShouldFailIfResponseIsNotJson()
-  {
-    $notJson = '{"foo": , this is cannot be passed as json" "bar"}';
-    $httpHandler = getHandler([
-      buildResponse(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
-      buildResponse(200, [], $notJson),
-    ]);
-    $g = new GCECredentials();
-    $g->fetchAuthToken($httpHandler);
-  }
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage Invalid JSON response
+     */
+    public function testShouldFailIfResponseIsNotJson()
+    {
+        $notJson = '{"foo": , this is cannot be passed as json" "bar"}';
+        $httpHandler = getHandler([
+            buildResponse(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
+            buildResponse(200, [], $notJson),
+        ]);
+        $g = new GCECredentials();
+        $g->fetchAuthToken($httpHandler);
+    }
 
-  public function testShouldReturnTokenInfo()
-  {
-    $wantedTokens = [
-        'access_token' => '1/abdef1234567890',
-        'expires_in' => '57',
-        'token_type' => 'Bearer',
-    ];
-    $jsonTokens = json_encode($wantedTokens);
-    $httpHandler = getHandler([
-      buildResponse(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
-      buildResponse(200, [], Psr7\stream_for($jsonTokens)),
-    ]);
-    $g = new GCECredentials();
-    $this->assertEquals($wantedTokens, $g->fetchAuthToken($httpHandler));
-    $this->assertEquals(time() + 57, $g->getLastReceivedToken()['expires_at']);
-  }
+    public function testShouldReturnTokenInfo()
+    {
+        $wantedTokens = [
+            'access_token' => '1/abdef1234567890',
+            'expires_in' => '57',
+            'token_type' => 'Bearer',
+        ];
+        $jsonTokens = json_encode($wantedTokens);
+        $httpHandler = getHandler([
+            buildResponse(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
+            buildResponse(200, [], Psr7\stream_for($jsonTokens)),
+        ]);
+        $g = new GCECredentials();
+        $this->assertEquals($wantedTokens, $g->fetchAuthToken($httpHandler));
+        $this->assertEquals(time() + 57, $g->getLastReceivedToken()['expires_at']);
+    }
 }

--- a/tests/Credentials/IAMCredentialsTest.php
+++ b/tests/Credentials/IAMCredentialsTest.php
@@ -21,63 +21,63 @@ use Google\Auth\Credentials\IAMCredentials;
 
 class IAMConstructorTest extends \PHPUnit_Framework_TestCase
 {
-  /**
-   * @expectedException InvalidArgumentException
-   */
-  public function testShouldFailIfSelectorIsNotString()
-  {
-    $notAString = new \stdClass();
-    $iam = new IAMCredentials(
-        $notAString,
-        ""
-    );
-  }
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testShouldFailIfSelectorIsNotString()
+    {
+        $notAString = new \stdClass();
+        $iam = new IAMCredentials(
+            $notAString,
+            ''
+        );
+    }
 
-  /**
-   * @expectedException InvalidArgumentException
-   */
-  public function testShouldFailIfTokenIsNotString()
-  {
-    $notAString = new \stdClass();
-    $iam = new IAMCredentials(
-        "",
-        $notAString
-    );
-  }
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testShouldFailIfTokenIsNotString()
+    {
+        $notAString = new \stdClass();
+        $iam = new IAMCredentials(
+            '',
+            $notAString
+        );
+    }
 
-  public function testInitializeSuccess()
-  {
-    $this->assertNotNull(
-        new IAMCredentials("iam-selector", "iam-token")
-    );
-  }
+    public function testInitializeSuccess()
+    {
+        $this->assertNotNull(
+            new IAMCredentials('iam-selector', 'iam-token')
+        );
+    }
 }
 
 class IAMUpdateMetadataCallbackTest extends \PHPUnit_Framework_TestCase
 {
-  public function testUpdateMetadataFunc()
-  {
-    $selector = 'iam-selector';
-    $token = 'iam-token';
-    $iam = new IAMCredentials(
-        $selector,
-        $token
-    );
+    public function testUpdateMetadataFunc()
+    {
+        $selector = 'iam-selector';
+        $token = 'iam-token';
+        $iam = new IAMCredentials(
+            $selector,
+            $token
+        );
 
-    $update_metadata = $iam->getUpdateMetadataFunc();
-    $this->assertTrue(is_callable($update_metadata));
+        $update_metadata = $iam->getUpdateMetadataFunc();
+        $this->assertTrue(is_callable($update_metadata));
 
-    $actual_metadata = call_user_func($update_metadata,
-                                      $metadata = array('foo' => 'bar'));
-    $this->assertTrue(
-        isset($actual_metadata[IAMCredentials::SELECTOR_KEY]));
-    $this->assertEquals(
-        $actual_metadata[IAMCredentials::SELECTOR_KEY],
-        $selector);
-    $this->assertTrue(
-        isset($actual_metadata[IAMCredentials::TOKEN_KEY]));
-    $this->assertEquals(
-        $actual_metadata[IAMCredentials::TOKEN_KEY],
-        $token);
-  }
+        $actual_metadata = call_user_func($update_metadata,
+            $metadata = array('foo' => 'bar'));
+        $this->assertTrue(
+            isset($actual_metadata[IAMCredentials::SELECTOR_KEY]));
+        $this->assertEquals(
+            $actual_metadata[IAMCredentials::SELECTOR_KEY],
+            $selector);
+        $this->assertTrue(
+            isset($actual_metadata[IAMCredentials::TOKEN_KEY]));
+        $this->assertEquals(
+            $actual_metadata[IAMCredentials::TOKEN_KEY],
+            $token);
+    }
 }

--- a/tests/Credentials/ServiceAccountCredentialsTest.php
+++ b/tests/Credentials/ServiceAccountCredentialsTest.php
@@ -18,494 +18,491 @@
 namespace Google\Auth\Tests;
 
 use Google\Auth\ApplicationDefaultCredentials;
-use Google\Auth\CredentialsLoader;
 use Google\Auth\Credentials\ServiceAccountCredentials;
 use Google\Auth\Credentials\ServiceAccountJwtAccessCredentials;
-use Google\Auth\HttpHandler\Guzzle6HttpHandler;
+use Google\Auth\CredentialsLoader;
 use Google\Auth\OAuth2;
-use GuzzleHttp\Client;
 use GuzzleHttp\Psr7;
-use GuzzleHttp\Psr7\Response;
 
 // Creates a standard JSON auth object for testing.
 function createTestJson()
 {
-  return [
-      'private_key_id' => 'key123',
-      'private_key' => 'privatekey',
-      'client_email' => 'test@example.com',
-      'client_id' => 'client123',
-      'type' => 'service_account'
-  ];
+    return [
+        'private_key_id' => 'key123',
+        'private_key' => 'privatekey',
+        'client_email' => 'test@example.com',
+        'client_id' => 'client123',
+        'type' => 'service_account',
+    ];
 }
 
 class SACGetCacheKeyTest extends \PHPUnit_Framework_TestCase
 {
-  public function testShouldBeTheSameAsOAuth2WithTheSameScope()
-  {
-    $testJson = createTestJson();
-    $scope = ['scope/1', 'scope/2'];
-    $sa = new ServiceAccountCredentials(
-        $scope,
-        $testJson);
-    $o = new OAuth2(['scope' => $scope]);
-    $this->assertSame(
-        $testJson['client_email'] . ':' . $o->getCacheKey(),
-        $sa->getCacheKey()
-    );
-  }
+    public function testShouldBeTheSameAsOAuth2WithTheSameScope()
+    {
+        $testJson = createTestJson();
+        $scope = ['scope/1', 'scope/2'];
+        $sa = new ServiceAccountCredentials(
+            $scope,
+            $testJson);
+        $o = new OAuth2(['scope' => $scope]);
+        $this->assertSame(
+            $testJson['client_email'].':'.$o->getCacheKey(),
+            $sa->getCacheKey()
+        );
+    }
 
-  public function testShouldBeTheSameAsOAuth2WithTheSameScopeWithSub()
-  {
-    $testJson = createTestJson();
-    $scope = ['scope/1', 'scope/2'];
-    $sub = 'sub123';
-    $sa = new ServiceAccountCredentials(
-        $scope,
-        $testJson,
-        $sub);
-    $o = new OAuth2(['scope' => $scope]);
-    $this->assertSame(
-        $testJson['client_email'] . ':' . $o->getCacheKey() . ':' . $sub,
-        $sa->getCacheKey()
-    );
-  }
+    public function testShouldBeTheSameAsOAuth2WithTheSameScopeWithSub()
+    {
+        $testJson = createTestJson();
+        $scope = ['scope/1', 'scope/2'];
+        $sub = 'sub123';
+        $sa = new ServiceAccountCredentials(
+            $scope,
+            $testJson,
+            $sub);
+        $o = new OAuth2(['scope' => $scope]);
+        $this->assertSame(
+            $testJson['client_email'].':'.$o->getCacheKey().':'.$sub,
+            $sa->getCacheKey()
+        );
+    }
 
-  public function testShouldBeTheSameAsOAuth2WithTheSameScopeWithSubAddedLater()
-  {
-    $testJson = createTestJson();
-    $scope = ['scope/1', 'scope/2'];
-    $sub = 'sub123';
-    $sa = new ServiceAccountCredentials(
-        $scope,
-        $testJson,
-        null);
-    $sa->setSub($sub);
+    public function testShouldBeTheSameAsOAuth2WithTheSameScopeWithSubAddedLater()
+    {
+        $testJson = createTestJson();
+        $scope = ['scope/1', 'scope/2'];
+        $sub = 'sub123';
+        $sa = new ServiceAccountCredentials(
+            $scope,
+            $testJson,
+            null);
+        $sa->setSub($sub);
 
-    $o = new OAuth2(['scope' => $scope]);
-    $this->assertSame(
-        $testJson['client_email'] . ':' . $o->getCacheKey() . ':' . $sub,
-        $sa->getCacheKey()
-    );
-  }
+        $o = new OAuth2(['scope' => $scope]);
+        $this->assertSame(
+            $testJson['client_email'].':'.$o->getCacheKey().':'.$sub,
+            $sa->getCacheKey()
+        );
+    }
 }
 
 class SACConstructorTest extends \PHPUnit_Framework_TestCase
 {
-  /**
-   * @expectedException InvalidArgumentException
-   */
-  public function testShouldFailIfScopeIsNotAValidType()
-  {
-    $testJson = createTestJson();
-    $notAnArrayOrString = new \stdClass();
-    $sa = new ServiceAccountCredentials(
-        $notAnArrayOrString,
-        $testJson
-    );
-  }
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testShouldFailIfScopeIsNotAValidType()
+    {
+        $testJson = createTestJson();
+        $notAnArrayOrString = new \stdClass();
+        $sa = new ServiceAccountCredentials(
+            $notAnArrayOrString,
+            $testJson
+        );
+    }
 
-  /**
-   * @expectedException InvalidArgumentException
-   */
-  public function testShouldFailIfJsonDoesNotHaveClientEmail()
-  {
-    $testJson = createTestJson();
-    unset($testJson['client_email']);
-    $scope = ['scope/1', 'scope/2'];
-    $sa = new ServiceAccountCredentials(
-        $scope,
-        $testJson
-    );
-  }
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testShouldFailIfJsonDoesNotHaveClientEmail()
+    {
+        $testJson = createTestJson();
+        unset($testJson['client_email']);
+        $scope = ['scope/1', 'scope/2'];
+        $sa = new ServiceAccountCredentials(
+            $scope,
+            $testJson
+        );
+    }
 
-  /**
-   * @expectedException InvalidArgumentException
-   */
-  public function testShouldFailIfJsonDoesNotHavePrivateKey()
-  {
-    $testJson = createTestJson();
-    unset($testJson['private_key']);
-    $scope = ['scope/1', 'scope/2'];
-    $sa = new ServiceAccountCredentials(
-        $scope,
-        $testJson
-    );
-  }
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testShouldFailIfJsonDoesNotHavePrivateKey()
+    {
+        $testJson = createTestJson();
+        unset($testJson['private_key']);
+        $scope = ['scope/1', 'scope/2'];
+        $sa = new ServiceAccountCredentials(
+            $scope,
+            $testJson
+        );
+    }
 
-  /**
-   * @expectedException InvalidArgumentException
-   */
-  public function testFailsToInitalizeFromANonExistentFile()
-  {
-    $keyFile = __DIR__ . '/../fixtures' . '/does-not-exist-private.json';
-    new ServiceAccountCredentials('scope/1', $keyFile);
-  }
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testFailsToInitalizeFromANonExistentFile()
+    {
+        $keyFile = __DIR__.'/../fixtures'.'/does-not-exist-private.json';
+        new ServiceAccountCredentials('scope/1', $keyFile);
+    }
 
-  public function testInitalizeFromAFile()
-  {
-    $keyFile = __DIR__ . '/../fixtures' . '/private.json';
-    $this->assertNotNull(
-        new ServiceAccountCredentials('scope/1', $keyFile)
-    );
-  }
+    public function testInitalizeFromAFile()
+    {
+        $keyFile = __DIR__.'/../fixtures'.'/private.json';
+        $this->assertNotNull(
+            new ServiceAccountCredentials('scope/1', $keyFile)
+        );
+    }
 }
 
 class SACFromEnvTest extends \PHPUnit_Framework_TestCase
 {
-  protected function tearDown()
-  {
-    putenv(ServiceAccountCredentials::ENV_VAR);  // removes it from
-  }
+    protected function tearDown()
+    {
+        putenv(ServiceAccountCredentials::ENV_VAR);  // removes it from
+    }
 
-  public function testIsNullIfEnvVarIsNotSet()
-  {
-    $this->assertNull(ServiceAccountCredentials::fromEnv('a scope'));
-  }
+    public function testIsNullIfEnvVarIsNotSet()
+    {
+        $this->assertNull(ServiceAccountCredentials::fromEnv('a scope'));
+    }
 
-  /**
-   * @expectedException DomainException
-   */
-  public function testFailsIfEnvSpecifiesNonExistentFile()
-  {
-    $keyFile = __DIR__ . '/../fixtures' . '/does-not-exist-private.json';
-    putenv(ServiceAccountCredentials::ENV_VAR . '=' . $keyFile);
-    ApplicationDefaultCredentials::getCredentials('a scope');
-  }
+    /**
+     * @expectedException DomainException
+     */
+    public function testFailsIfEnvSpecifiesNonExistentFile()
+    {
+        $keyFile = __DIR__.'/../fixtures'.'/does-not-exist-private.json';
+        putenv(ServiceAccountCredentials::ENV_VAR.'='.$keyFile);
+        ApplicationDefaultCredentials::getCredentials('a scope');
+    }
 
-  public function testSucceedIfFileExists()
-  {
-    $keyFile = __DIR__ . '/../fixtures' . '/private.json';
-    putenv(ServiceAccountCredentials::ENV_VAR . '=' . $keyFile);
-    $this->assertNotNull(ApplicationDefaultCredentials::getCredentials('a scope'));
-  }
+    public function testSucceedIfFileExists()
+    {
+        $keyFile = __DIR__.'/../fixtures'.'/private.json';
+        putenv(ServiceAccountCredentials::ENV_VAR.'='.$keyFile);
+        $this->assertNotNull(ApplicationDefaultCredentials::getCredentials('a scope'));
+    }
 }
 
 class SACFromWellKnownFileTest extends \PHPUnit_Framework_TestCase
 {
-  private $originalHome;
+    private $originalHome;
 
-  protected function setUp()
-  {
-    $this->originalHome = getenv('HOME');
-  }
-
-  protected function tearDown()
-  {
-    if ($this->originalHome != getenv('HOME')) {
-      putenv('HOME=' . $this->originalHome);
+    protected function setUp()
+    {
+        $this->originalHome = getenv('HOME');
     }
-  }
 
-  public function testIsNullIfFileDoesNotExist()
-  {
-    putenv('HOME=' . __DIR__ . '/../not_exists_fixtures');
-    $this->assertNull(
-        ServiceAccountCredentials::fromWellKnownFile('a scope')
-    );
-  }
+    protected function tearDown()
+    {
+        if ($this->originalHome != getenv('HOME')) {
+            putenv('HOME='.$this->originalHome);
+        }
+    }
 
-  public function testSucceedIfFileIsPresent()
-  {
-    putenv('HOME=' . __DIR__ . '/../fixtures');
-    $this->assertNotNull(
-        ApplicationDefaultCredentials::getCredentials('a scope')
-    );
-  }
+    public function testIsNullIfFileDoesNotExist()
+    {
+        putenv('HOME='.__DIR__.'/../not_exists_fixtures');
+        $this->assertNull(
+            ServiceAccountCredentials::fromWellKnownFile('a scope')
+        );
+    }
+
+    public function testSucceedIfFileIsPresent()
+    {
+        putenv('HOME='.__DIR__.'/../fixtures');
+        $this->assertNotNull(
+            ApplicationDefaultCredentials::getCredentials('a scope')
+        );
+    }
 }
 
 class SACFetchAuthTokenTest extends \PHPUnit_Framework_TestCase
 {
-  private $privateKey;
+    private $privateKey;
 
-  public function setUp()
-  {
-    $this->privateKey =
-        file_get_contents(__DIR__ . '/../fixtures' . '/private.pem');
-  }
+    public function setUp()
+    {
+        $this->privateKey =
+            file_get_contents(__DIR__.'/../fixtures'.'/private.pem');
+    }
 
-  private function createTestJson()
-  {
-    $testJson = createTestJson();
-    $testJson['private_key'] = $this->privateKey;
-    return $testJson;
-  }
+    private function createTestJson()
+    {
+        $testJson = createTestJson();
+        $testJson['private_key'] = $this->privateKey;
 
-  /**
-   * @expectedException GuzzleHttp\Exception\ClientException
-   */
-  public function testFailsOnClientErrors()
-  {
-    $testJson = $this->createTestJson();
-    $scope = ['scope/1', 'scope/2'];
-    $httpHandler = getHandler([
-      buildResponse(400)
-    ]);
-    $sa = new ServiceAccountCredentials(
-        $scope,
-        $testJson
-    );
-    $sa->fetchAuthToken($httpHandler);
-  }
+        return $testJson;
+    }
 
-  /**
-   * @expectedException GuzzleHttp\Exception\ServerException
-   */
-  public function testFailsOnServerErrors()
-  {
-    $testJson = $this->createTestJson();
-    $scope = ['scope/1', 'scope/2'];
-    $httpHandler = getHandler([
-      buildResponse(500)
-    ]);
-    $sa = new ServiceAccountCredentials(
-        $scope,
-        $testJson
-    );
-    $sa->fetchAuthToken($httpHandler);
-  }
+    /**
+     * @expectedException GuzzleHttp\Exception\ClientException
+     */
+    public function testFailsOnClientErrors()
+    {
+        $testJson = $this->createTestJson();
+        $scope = ['scope/1', 'scope/2'];
+        $httpHandler = getHandler([
+            buildResponse(400),
+        ]);
+        $sa = new ServiceAccountCredentials(
+            $scope,
+            $testJson
+        );
+        $sa->fetchAuthToken($httpHandler);
+    }
 
-  public function testCanFetchCredsOK()
-  {
-    $testJson = $this->createTestJson();
-    $testJsonText = json_encode($testJson);
-    $scope = ['scope/1', 'scope/2'];
-    $httpHandler = getHandler([
-      buildResponse(200, [], Psr7\stream_for($testJsonText))
-    ]);
-    $sa = new ServiceAccountCredentials(
-        $scope,
-        $testJson
-    );
-    $tokens = $sa->fetchAuthToken($httpHandler);
-    $this->assertEquals($testJson, $tokens);
-  }
+    /**
+     * @expectedException GuzzleHttp\Exception\ServerException
+     */
+    public function testFailsOnServerErrors()
+    {
+        $testJson = $this->createTestJson();
+        $scope = ['scope/1', 'scope/2'];
+        $httpHandler = getHandler([
+            buildResponse(500),
+        ]);
+        $sa = new ServiceAccountCredentials(
+            $scope,
+            $testJson
+        );
+        $sa->fetchAuthToken($httpHandler);
+    }
 
-  public function testUpdateMetadataFunc()
-  {
-    $testJson = $this->createTestJson();
-    $scope = ['scope/1', 'scope/2'];
-    $access_token = 'accessToken123';
-    $responseText = json_encode(array('access_token' => $access_token));
-    $httpHandler = getHandler([
-      buildResponse(200, [], Psr7\stream_for($responseText))
-    ]);
-    $sa = new ServiceAccountCredentials(
-        $scope,
-        $testJson
-    );
-    $update_metadata = $sa->getUpdateMetadataFunc();
-    $this->assertTrue(is_callable($update_metadata));
+    public function testCanFetchCredsOK()
+    {
+        $testJson = $this->createTestJson();
+        $testJsonText = json_encode($testJson);
+        $scope = ['scope/1', 'scope/2'];
+        $httpHandler = getHandler([
+            buildResponse(200, [], Psr7\stream_for($testJsonText)),
+        ]);
+        $sa = new ServiceAccountCredentials(
+            $scope,
+            $testJson
+        );
+        $tokens = $sa->fetchAuthToken($httpHandler);
+        $this->assertEquals($testJson, $tokens);
+    }
 
-    $actual_metadata = call_user_func($update_metadata,
-                               $metadata = array('foo' => 'bar'),
-                               $authUri = null,
-                               $httpHandler);
-    $this->assertTrue(
-        isset($actual_metadata[CredentialsLoader::AUTH_METADATA_KEY]));
-    $this->assertEquals(
-        $actual_metadata[CredentialsLoader::AUTH_METADATA_KEY],
-        array('Bearer ' . $access_token));
-  }
+    public function testUpdateMetadataFunc()
+    {
+        $testJson = $this->createTestJson();
+        $scope = ['scope/1', 'scope/2'];
+        $access_token = 'accessToken123';
+        $responseText = json_encode(array('access_token' => $access_token));
+        $httpHandler = getHandler([
+            buildResponse(200, [], Psr7\stream_for($responseText)),
+        ]);
+        $sa = new ServiceAccountCredentials(
+            $scope,
+            $testJson
+        );
+        $update_metadata = $sa->getUpdateMetadataFunc();
+        $this->assertTrue(is_callable($update_metadata));
+
+        $actual_metadata = call_user_func($update_metadata,
+            $metadata = array('foo' => 'bar'),
+            $authUri = null,
+            $httpHandler);
+        $this->assertTrue(
+            isset($actual_metadata[CredentialsLoader::AUTH_METADATA_KEY]));
+        $this->assertEquals(
+            $actual_metadata[CredentialsLoader::AUTH_METADATA_KEY],
+            array('Bearer '.$access_token));
+    }
 }
 
 class SACJwtAccessTest extends \PHPUnit_Framework_TestCase
 {
-  private $privateKey;
+    private $privateKey;
 
-  public function setUp()
-  {
-    $this->privateKey =
-        file_get_contents(__DIR__ . '/../fixtures' . '/private.pem');
-  }
+    public function setUp()
+    {
+        $this->privateKey =
+            file_get_contents(__DIR__.'/../fixtures'.'/private.pem');
+    }
 
-  private function createTestJson()
-  {
-    $testJson = createTestJson();
-    $testJson['private_key'] = $this->privateKey;
-    return $testJson;
-  }
+    private function createTestJson()
+    {
+        $testJson = createTestJson();
+        $testJson['private_key'] = $this->privateKey;
 
-  /**
-   * @expectedException InvalidArgumentException
-   */
-  public function testFailsOnMissingClientEmail()
-  {
-    $testJson = $this->createTestJson();
-    unset($testJson['client_email']);
-    $sa = new ServiceAccountJwtAccessCredentials(
-        $testJson
-    );
-  }
+        return $testJson;
+    }
 
-  /**
-   * @expectedException InvalidArgumentException
-   */
-  public function testFailsOnMissingPrivateKey()
-  {
-    $testJson = $this->createTestJson();
-    unset($testJson['private_key']);
-    $sa = new ServiceAccountJwtAccessCredentials(
-        $testJson
-    );
-  }
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testFailsOnMissingClientEmail()
+    {
+        $testJson = $this->createTestJson();
+        unset($testJson['client_email']);
+        $sa = new ServiceAccountJwtAccessCredentials(
+            $testJson
+        );
+    }
 
-  public function testCanInitializeFromJson()
-  {
-    $testJson = $this->createTestJson();
-    $sa = new ServiceAccountJwtAccessCredentials(
-        $testJson
-    );
-    $this->assertNotNull($sa);
-  }
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testFailsOnMissingPrivateKey()
+    {
+        $testJson = $this->createTestJson();
+        unset($testJson['private_key']);
+        $sa = new ServiceAccountJwtAccessCredentials(
+            $testJson
+        );
+    }
 
+    public function testCanInitializeFromJson()
+    {
+        $testJson = $this->createTestJson();
+        $sa = new ServiceAccountJwtAccessCredentials(
+            $testJson
+        );
+        $this->assertNotNull($sa);
+    }
 
-  public function testNoOpOnFetchAuthToken()
-  {
-    $testJson = $this->createTestJson();
-    $sa = new ServiceAccountJwtAccessCredentials(
-        $testJson
-    );
-    $this->assertNotNull($sa);
+    public function testNoOpOnFetchAuthToken()
+    {
+        $testJson = $this->createTestJson();
+        $sa = new ServiceAccountJwtAccessCredentials(
+            $testJson
+        );
+        $this->assertNotNull($sa);
 
-    $httpHandler = getHandler([
-      buildResponse(200)
-    ]);
-    $result = $sa->fetchAuthToken($httpHandler); // authUri has not been set
-    $this->assertNull($result);
-  }
+        $httpHandler = getHandler([
+            buildResponse(200),
+        ]);
+        $result = $sa->fetchAuthToken($httpHandler); // authUri has not been set
+        $this->assertNull($result);
+    }
 
+    public function testAuthUriIsNotSet()
+    {
+        $testJson = $this->createTestJson();
+        $sa = new ServiceAccountJwtAccessCredentials(
+            $testJson
+        );
+        $this->assertNotNull($sa);
 
-  public function testAuthUriIsNotSet()
-  {
-    $testJson = $this->createTestJson();
-    $sa = new ServiceAccountJwtAccessCredentials(
-        $testJson
-    );
-    $this->assertNotNull($sa);
+        $update_metadata = $sa->getUpdateMetadataFunc();
+        $this->assertTrue(is_callable($update_metadata));
 
-    $update_metadata = $sa->getUpdateMetadataFunc();
-    $this->assertTrue(is_callable($update_metadata));
+        $actual_metadata = call_user_func($update_metadata,
+            $metadata = array('foo' => 'bar'),
+            $authUri = null);
+        $this->assertTrue(
+            !isset($actual_metadata[CredentialsLoader::AUTH_METADATA_KEY]));
+    }
 
-    $actual_metadata = call_user_func($update_metadata,
-                               $metadata = array('foo' => 'bar'),
-                               $authUri = null);
-    $this->assertTrue(
-        !isset($actual_metadata[CredentialsLoader::AUTH_METADATA_KEY]));
-  }
+    public function testUpdateMetadataFunc()
+    {
+        $testJson = $this->createTestJson();
+        $sa = new ServiceAccountJwtAccessCredentials(
+            $testJson
+        );
+        $this->assertNotNull($sa);
 
-  public function testUpdateMetadataFunc()
-  {
-    $testJson = $this->createTestJson();
-    $sa = new ServiceAccountJwtAccessCredentials(
-        $testJson
-    );
-    $this->assertNotNull($sa);
+        $update_metadata = $sa->getUpdateMetadataFunc();
+        $this->assertTrue(is_callable($update_metadata));
 
-    $update_metadata = $sa->getUpdateMetadataFunc();
-    $this->assertTrue(is_callable($update_metadata));
+        $actual_metadata = call_user_func($update_metadata,
+            $metadata = array('foo' => 'bar'),
+            $authUri = 'https://example.com/service');
+        $this->assertTrue(
+            isset($actual_metadata[CredentialsLoader::AUTH_METADATA_KEY]));
 
-    $actual_metadata = call_user_func($update_metadata,
-                               $metadata = array('foo' => 'bar'),
-                               $authUri = 'https://example.com/service');
-    $this->assertTrue(
-        isset($actual_metadata[CredentialsLoader::AUTH_METADATA_KEY]));
+        $authorization = $actual_metadata[CredentialsLoader::AUTH_METADATA_KEY];
+        $this->assertTrue(is_array($authorization));
 
-    $authorization = $actual_metadata[CredentialsLoader::AUTH_METADATA_KEY];
-    $this->assertTrue(is_array($authorization));
+        $bearer_token = current($authorization);
+        $this->assertTrue(is_string($bearer_token));
+        $this->assertTrue(strpos($bearer_token, 'Bearer ') == 0);
+        $this->assertTrue(strlen($bearer_token) > 30);
 
-    $bearer_token = current($authorization);
-    $this->assertTrue(is_string($bearer_token));
-    $this->assertTrue(strpos($bearer_token, 'Bearer ') == 0);
-    $this->assertTrue(strlen($bearer_token) > 30);
+        $actual_metadata2 = call_user_func($update_metadata,
+            $metadata = array('foo' => 'bar'),
+            $authUri = 'https://example.com/anotherService');
+        $this->assertTrue(
+            isset($actual_metadata2[CredentialsLoader::AUTH_METADATA_KEY]));
 
-    $actual_metadata2 = call_user_func($update_metadata,
-                               $metadata = array('foo' => 'bar'),
-                               $authUri = 'https://example.com/anotherService');
-    $this->assertTrue(
-        isset($actual_metadata2[CredentialsLoader::AUTH_METADATA_KEY]));
+        $authorization2 = $actual_metadata2[CredentialsLoader::AUTH_METADATA_KEY];
+        $this->assertTrue(is_array($authorization2));
 
-    $authorization2 = $actual_metadata2[CredentialsLoader::AUTH_METADATA_KEY];
-    $this->assertTrue(is_array($authorization2));
-
-    $bearer_token2 = current($authorization2);
-    $this->assertTrue(is_string($bearer_token2));
-    $this->assertTrue(strpos($bearer_token2, 'Bearer ') == 0);
-    $this->assertTrue(strlen($bearer_token2) > 30);
-    $this->assertTrue($bearer_token != $bearer_token2);
-  }
-
+        $bearer_token2 = current($authorization2);
+        $this->assertTrue(is_string($bearer_token2));
+        $this->assertTrue(strpos($bearer_token2, 'Bearer ') == 0);
+        $this->assertTrue(strlen($bearer_token2) > 30);
+        $this->assertTrue($bearer_token != $bearer_token2);
+    }
 }
 
 class SACJwtAccessComboTest extends \PHPUnit_Framework_TestCase
 {
-  private $privateKey;
+    private $privateKey;
 
-  public function setUp()
-  {
-    $this->privateKey =
-        file_get_contents(__DIR__ . '/../fixtures' . '/private.pem');
-  }
+    public function setUp()
+    {
+        $this->privateKey =
+            file_get_contents(__DIR__.'/../fixtures'.'/private.pem');
+    }
 
-  private function createTestJson()
-  {
-    $testJson = createTestJson();
-    $testJson['private_key'] = $this->privateKey;
-    return $testJson;
-  }
+    private function createTestJson()
+    {
+        $testJson = createTestJson();
+        $testJson['private_key'] = $this->privateKey;
 
-  public function testNoScopeUseJwtAccess()
-  {
-    $testJson = $this->createTestJson();
-    // no scope, jwt access should be used, no outbound
-    // call should be made
-    $scope = null;
-    $sa = new ServiceAccountCredentials(
-        $scope,
-        $testJson
-    );
-    $this->assertNotNull($sa);
+        return $testJson;
+    }
 
-    $update_metadata = $sa->getUpdateMetadataFunc();
-    $this->assertTrue(is_callable($update_metadata));
+    public function testNoScopeUseJwtAccess()
+    {
+        $testJson = $this->createTestJson();
+        // no scope, jwt access should be used, no outbound
+        // call should be made
+        $scope = null;
+        $sa = new ServiceAccountCredentials(
+            $scope,
+            $testJson
+        );
+        $this->assertNotNull($sa);
 
-    $actual_metadata = call_user_func($update_metadata,
-                               $metadata = array('foo' => 'bar'),
-                               $authUri = 'https://example.com/service');
-    $this->assertTrue(
-        isset($actual_metadata[CredentialsLoader::AUTH_METADATA_KEY]));
+        $update_metadata = $sa->getUpdateMetadataFunc();
+        $this->assertTrue(is_callable($update_metadata));
 
-    $authorization = $actual_metadata[CredentialsLoader::AUTH_METADATA_KEY];
-    $this->assertTrue(is_array($authorization));
+        $actual_metadata = call_user_func($update_metadata,
+            $metadata = array('foo' => 'bar'),
+            $authUri = 'https://example.com/service');
+        $this->assertTrue(
+            isset($actual_metadata[CredentialsLoader::AUTH_METADATA_KEY]));
 
-    $bearer_token = current($authorization);
-    $this->assertTrue(is_string($bearer_token));
-    $this->assertTrue(strpos($bearer_token, 'Bearer ') == 0);
-    $this->assertTrue(strlen($bearer_token) > 30);
-  }
+        $authorization = $actual_metadata[CredentialsLoader::AUTH_METADATA_KEY];
+        $this->assertTrue(is_array($authorization));
 
-  public function testNoScopeAndNoAuthUri()
-  {
-    $testJson = $this->createTestJson();
-    // no scope, jwt access should be used, no outbound
-    // call should be made
-    $scope = null;
-    $sa = new ServiceAccountCredentials(
-        $scope,
-        $testJson
-    );
-    $this->assertNotNull($sa);
+        $bearer_token = current($authorization);
+        $this->assertTrue(is_string($bearer_token));
+        $this->assertTrue(strpos($bearer_token, 'Bearer ') == 0);
+        $this->assertTrue(strlen($bearer_token) > 30);
+    }
 
-    $update_metadata = $sa->getUpdateMetadataFunc();
-    $this->assertTrue(is_callable($update_metadata));
+    public function testNoScopeAndNoAuthUri()
+    {
+        $testJson = $this->createTestJson();
+        // no scope, jwt access should be used, no outbound
+        // call should be made
+        $scope = null;
+        $sa = new ServiceAccountCredentials(
+            $scope,
+            $testJson
+        );
+        $this->assertNotNull($sa);
 
-    $actual_metadata = call_user_func($update_metadata,
-                                      $metadata = array('foo' => 'bar'),
-                                      $authUri = null);
-    // no access_token is added to the metadata hash
-    // but also, no error should be thrown
-    $this->assertTrue(is_array($actual_metadata));
-    $this->assertTrue(
-        !isset($actual_metadata[CredentialsLoader::AUTH_METADATA_KEY]));
-  }
+        $update_metadata = $sa->getUpdateMetadataFunc();
+        $this->assertTrue(is_callable($update_metadata));
+
+        $actual_metadata = call_user_func($update_metadata,
+            $metadata = array('foo' => 'bar'),
+            $authUri = null);
+        // no access_token is added to the metadata hash
+        // but also, no error should be thrown
+        $this->assertTrue(is_array($actual_metadata));
+        $this->assertTrue(
+            !isset($actual_metadata[CredentialsLoader::AUTH_METADATA_KEY]));
+    }
 }

--- a/tests/Credentials/UserRefreshCredentialsTest.php
+++ b/tests/Credentials/UserRefreshCredentialsTest.php
@@ -19,213 +19,210 @@ namespace Google\Auth\Tests;
 
 use Google\Auth\ApplicationDefaultCredentials;
 use Google\Auth\Credentials\UserRefreshCredentials;
-use Google\Auth\HttpHandler\Guzzle6HttpHandler;
 use Google\Auth\OAuth2;
-use GuzzleHttp\Client;
 use GuzzleHttp\Psr7;
-use GuzzleHttp\Psr7\Response;
 
 // Creates a standard JSON auth object for testing.
 function createURCTestJson()
 {
-  return [
-      'client_id' => 'client123',
-      'client_secret' => 'clientSecret123',
-      'refresh_token' => 'refreshToken123',
-      'type' => 'authorized_user'
-  ];
+    return [
+        'client_id' => 'client123',
+        'client_secret' => 'clientSecret123',
+        'refresh_token' => 'refreshToken123',
+        'type' => 'authorized_user',
+    ];
 }
 
 class URCGetCacheKeyTest extends \PHPUnit_Framework_TestCase
 {
-  public function testShouldBeTheSameAsOAuth2WithTheSameScope()
-  {
-    $testJson = createURCTestJson();
-    $scope = ['scope/1', 'scope/2'];
-    $sa = new UserRefreshCredentials(
-        $scope,
-        $testJson);
-    $o = new OAuth2(['scope' => $scope]);
-    $this->assertSame(
-        $testJson['client_id'] . ':' . $o->getCacheKey(),
-        $sa->getCacheKey()
-    );
-  }
+    public function testShouldBeTheSameAsOAuth2WithTheSameScope()
+    {
+        $testJson = createURCTestJson();
+        $scope = ['scope/1', 'scope/2'];
+        $sa = new UserRefreshCredentials(
+            $scope,
+            $testJson);
+        $o = new OAuth2(['scope' => $scope]);
+        $this->assertSame(
+            $testJson['client_id'].':'.$o->getCacheKey(),
+            $sa->getCacheKey()
+        );
+    }
 }
 
 class URCConstructorTest extends \PHPUnit_Framework_TestCase
 {
-  /**
-   * @expectedException InvalidArgumentException
-   */
-  public function testShouldFailIfScopeIsNotAValidType()
-  {
-    $testJson = createURCTestJson();
-    $notAnArrayOrString = new \stdClass();
-    $sa = new UserRefreshCredentials(
-        $notAnArrayOrString,
-        $testJson
-    );
-  }
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testShouldFailIfScopeIsNotAValidType()
+    {
+        $testJson = createURCTestJson();
+        $notAnArrayOrString = new \stdClass();
+        $sa = new UserRefreshCredentials(
+            $notAnArrayOrString,
+            $testJson
+        );
+    }
 
-  /**
-   * @expectedException InvalidArgumentException
-   */
-  public function testShouldFailIfJsonDoesNotHaveClientSecret()
-  {
-    $testJson = createURCTestJson();
-    unset($testJson['client_secret']);
-    $scope = ['scope/1', 'scope/2'];
-    $sa = new UserRefreshCredentials(
-        $scope,
-        $testJson
-    );
-  }
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testShouldFailIfJsonDoesNotHaveClientSecret()
+    {
+        $testJson = createURCTestJson();
+        unset($testJson['client_secret']);
+        $scope = ['scope/1', 'scope/2'];
+        $sa = new UserRefreshCredentials(
+            $scope,
+            $testJson
+        );
+    }
 
-  /**
-   * @expectedException InvalidArgumentException
-   */
-  public function testShouldFailIfJsonDoesNotHaveRefreshToken()
-  {
-    $testJson = createURCTestJson();
-    unset($testJson['refresh_token']);
-    $scope = ['scope/1', 'scope/2'];
-    $sa = new UserRefreshCredentials(
-        $scope,
-        $testJson
-    );
-  }
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testShouldFailIfJsonDoesNotHaveRefreshToken()
+    {
+        $testJson = createURCTestJson();
+        unset($testJson['refresh_token']);
+        $scope = ['scope/1', 'scope/2'];
+        $sa = new UserRefreshCredentials(
+            $scope,
+            $testJson
+        );
+    }
 
-  /**
-   * @expectedException InvalidArgumentException
-   */
-  public function testFailsToInitalizeFromANonExistentFile()
-  {
-    $keyFile = __DIR__ . '/../fixtures' . '/does-not-exist-private.json';
-    new UserRefreshCredentials('scope/1', $keyFile);
-  }
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testFailsToInitalizeFromANonExistentFile()
+    {
+        $keyFile = __DIR__.'/../fixtures'.'/does-not-exist-private.json';
+        new UserRefreshCredentials('scope/1', $keyFile);
+    }
 
-  public function testInitalizeFromAFile()
-  {
-    $keyFile = __DIR__ . '/../fixtures2' . '/private.json';
-    $this->assertNotNull(
-        new UserRefreshCredentials('scope/1', $keyFile)
-    );
-  }
+    public function testInitalizeFromAFile()
+    {
+        $keyFile = __DIR__.'/../fixtures2'.'/private.json';
+        $this->assertNotNull(
+            new UserRefreshCredentials('scope/1', $keyFile)
+        );
+    }
 }
 
 class URCFromEnvTest extends \PHPUnit_Framework_TestCase
 {
-  protected function tearDown()
-  {
-    putenv(UserRefreshCredentials::ENV_VAR);  // removes it from
-  }
+    protected function tearDown()
+    {
+        putenv(UserRefreshCredentials::ENV_VAR);  // removes it from
+    }
 
-  public function testIsNullIfEnvVarIsNotSet()
-  {
-    $this->assertNull(UserRefreshCredentials::fromEnv('a scope'));
-  }
+    public function testIsNullIfEnvVarIsNotSet()
+    {
+        $this->assertNull(UserRefreshCredentials::fromEnv('a scope'));
+    }
 
-  /**
-   * @expectedException DomainException
-   */
-  public function testFailsIfEnvSpecifiesNonExistentFile()
-  {
-    $keyFile = __DIR__ . '/../fixtures' . '/does-not-exist-private.json';
-    putenv(UserRefreshCredentials::ENV_VAR . '=' . $keyFile);
-    UserRefreshCredentials::fromEnv('a scope');
-  }
+    /**
+     * @expectedException DomainException
+     */
+    public function testFailsIfEnvSpecifiesNonExistentFile()
+    {
+        $keyFile = __DIR__.'/../fixtures'.'/does-not-exist-private.json';
+        putenv(UserRefreshCredentials::ENV_VAR.'='.$keyFile);
+        UserRefreshCredentials::fromEnv('a scope');
+    }
 
-  public function testSucceedIfFileExists()
-  {
-    $keyFile = __DIR__ . '/../fixtures2' . '/private.json';
-    putenv(UserRefreshCredentials::ENV_VAR . '=' . $keyFile);
-    $this->assertNotNull(ApplicationDefaultCredentials::getCredentials('a scope'));
-  }
+    public function testSucceedIfFileExists()
+    {
+        $keyFile = __DIR__.'/../fixtures2'.'/private.json';
+        putenv(UserRefreshCredentials::ENV_VAR.'='.$keyFile);
+        $this->assertNotNull(ApplicationDefaultCredentials::getCredentials('a scope'));
+    }
 }
 
 class URCFromWellKnownFileTest extends \PHPUnit_Framework_TestCase
 {
-  private $originalHome;
+    private $originalHome;
 
-  protected function setUp()
-  {
-    $this->originalHome = getenv('HOME');
-  }
-
-  protected function tearDown()
-  {
-    if ($this->originalHome != getenv('HOME')) {
-      putenv('HOME=' . $this->originalHome);
+    protected function setUp()
+    {
+        $this->originalHome = getenv('HOME');
     }
-  }
 
-  public function testIsNullIfFileDoesNotExist()
-  {
-    putenv('HOME=' . __DIR__ . '/../not_exist_fixtures');
-    $this->assertNull(
-        UserRefreshCredentials::fromWellKnownFile('a scope')
-    );
-  }
+    protected function tearDown()
+    {
+        if ($this->originalHome != getenv('HOME')) {
+            putenv('HOME='.$this->originalHome);
+        }
+    }
 
-  public function testSucceedIfFileIsPresent()
-  {
-    putenv('HOME=' . __DIR__ . '/../fixtures2');
-    $this->assertNotNull(
-        ApplicationDefaultCredentials::getCredentials('a scope')
-    );
-  }
+    public function testIsNullIfFileDoesNotExist()
+    {
+        putenv('HOME='.__DIR__.'/../not_exist_fixtures');
+        $this->assertNull(
+            UserRefreshCredentials::fromWellKnownFile('a scope')
+        );
+    }
+
+    public function testSucceedIfFileIsPresent()
+    {
+        putenv('HOME='.__DIR__.'/../fixtures2');
+        $this->assertNotNull(
+            ApplicationDefaultCredentials::getCredentials('a scope')
+        );
+    }
 }
 
 class URCFetchAuthTokenTest extends \PHPUnit_Framework_TestCase
 {
-  /**
-   * @expectedException GuzzleHttp\Exception\ClientException
-   */
-  public function testFailsOnClientErrors()
-  {
-    $testJson = createURCTestJson();
-    $scope = ['scope/1', 'scope/2'];
-    $httpHandler = getHandler([
-      buildResponse(400)
-    ]);
-    $sa = new UserRefreshCredentials(
-        $scope,
-        $testJson
-    );
-    $sa->fetchAuthToken($httpHandler);
-  }
+    /**
+     * @expectedException GuzzleHttp\Exception\ClientException
+     */
+    public function testFailsOnClientErrors()
+    {
+        $testJson = createURCTestJson();
+        $scope = ['scope/1', 'scope/2'];
+        $httpHandler = getHandler([
+            buildResponse(400),
+        ]);
+        $sa = new UserRefreshCredentials(
+            $scope,
+            $testJson
+        );
+        $sa->fetchAuthToken($httpHandler);
+    }
 
-  /**
-   * @expectedException GuzzleHttp\Exception\ServerException
-   */
-  public function testFailsOnServerErrors()
-  {
-    $testJson = createURCTestJson();
-    $scope = ['scope/1', 'scope/2'];
-    $httpHandler = getHandler([
-      buildResponse(500)
-    ]);
-    $sa = new UserRefreshCredentials(
-        $scope,
-        $testJson
-    );
-    $sa->fetchAuthToken($httpHandler);
-  }
+    /**
+     * @expectedException GuzzleHttp\Exception\ServerException
+     */
+    public function testFailsOnServerErrors()
+    {
+        $testJson = createURCTestJson();
+        $scope = ['scope/1', 'scope/2'];
+        $httpHandler = getHandler([
+            buildResponse(500),
+        ]);
+        $sa = new UserRefreshCredentials(
+            $scope,
+            $testJson
+        );
+        $sa->fetchAuthToken($httpHandler);
+    }
 
-  public function testCanFetchCredsOK()
-  {
-    $testJson = createURCTestJson();
-    $testJsonText = json_encode($testJson);
-    $scope = ['scope/1', 'scope/2'];
-    $httpHandler = getHandler([
-      buildResponse(200, [], Psr7\stream_for($testJsonText))
-    ]);
-    $sa = new UserRefreshCredentials(
-        $scope,
-        $testJson
-    );
-    $tokens = $sa->fetchAuthToken($httpHandler);
-    $this->assertEquals($testJson, $tokens);
-  }
+    public function testCanFetchCredsOK()
+    {
+        $testJson = createURCTestJson();
+        $testJsonText = json_encode($testJson);
+        $scope = ['scope/1', 'scope/2'];
+        $httpHandler = getHandler([
+            buildResponse(200, [], Psr7\stream_for($testJsonText)),
+        ]);
+        $sa = new UserRefreshCredentials(
+            $scope,
+            $testJson
+        );
+        $tokens = $sa->fetchAuthToken($httpHandler);
+        $this->assertEquals($testJson, $tokens);
+    }
 }

--- a/tests/FetchAuthTokenTest.php
+++ b/tests/FetchAuthTokenTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Google\Auth\Tests;
+namespace Google\Auth\tests;
 
 use Google\Auth\Credentials\AppIdentityCredentials;
 use Google\Auth\Credentials\GCECredentials;
@@ -13,143 +13,143 @@ use Google\Auth\OAuth2;
 
 class FetchAuthTokenTest extends BaseTest
 {
-  /** @dataProvider provideAuthTokenFetcher */
-  public function testGetLastReceivedToken(FetchAuthTokenInterface $fetcher)
-  {
-    $accessToken = $fetcher->getLastReceivedToken();
+    /** @dataProvider provideAuthTokenFetcher */
+    public function testGetLastReceivedToken(FetchAuthTokenInterface $fetcher)
+    {
+        $accessToken = $fetcher->getLastReceivedToken();
 
-    $this->assertNotNull($accessToken);
-    $this->assertArrayHasKey('access_token', $accessToken);
-    $this->assertArrayHasKey('expires_at', $accessToken);
+        $this->assertNotNull($accessToken);
+        $this->assertArrayHasKey('access_token', $accessToken);
+        $this->assertArrayHasKey('expires_at', $accessToken);
 
-    $this->assertEquals('xyz', $accessToken['access_token']);
-    $this->assertEquals(strtotime('2001'), $accessToken['expires_at']);
-  }
+        $this->assertEquals('xyz', $accessToken['access_token']);
+        $this->assertEquals(strtotime('2001'), $accessToken['expires_at']);
+    }
 
-  public function provideAuthTokenFetcher()
-  {
-    $scopes = ['https://www.googleapis.com/auth/drive.readonly'];
-    $jsonPath = sprintf(
-      '%s/fixtures/.config/%s',
-      __DIR__,
-      CredentialsLoader::WELL_KNOWN_PATH
-    );
-    $jsonPath2 = sprintf(
-      '%s/fixtures2/.config/%s',
-      __DIR__,
-      CredentialsLoader::WELL_KNOWN_PATH
-    );
+    public function provideAuthTokenFetcher()
+    {
+        $scopes = ['https://www.googleapis.com/auth/drive.readonly'];
+        $jsonPath = sprintf(
+            '%s/fixtures/.config/%s',
+            __DIR__,
+            CredentialsLoader::WELL_KNOWN_PATH
+        );
+        $jsonPath2 = sprintf(
+            '%s/fixtures2/.config/%s',
+            __DIR__,
+            CredentialsLoader::WELL_KNOWN_PATH
+        );
 
-    return [
-      [ $this->getAppIdentityCredentials() ],
-      [ $this->getGCECredentials() ],
-      [ $this->getServiceAccountCredentials($scopes, $jsonPath) ],
-      [ $this->getServiceAccountJwtAccessCredentials($jsonPath) ],
-      [ $this->getUserRefreshCredentials($scopes, $jsonPath2) ],
-      [ $this->getOAuth2() ],
-    ];
-  }
+        return [
+            [$this->getAppIdentityCredentials()],
+            [$this->getGCECredentials()],
+            [$this->getServiceAccountCredentials($scopes, $jsonPath)],
+            [$this->getServiceAccountJwtAccessCredentials($jsonPath)],
+            [$this->getUserRefreshCredentials($scopes, $jsonPath2)],
+            [$this->getOAuth2()],
+        ];
+    }
 
-  private function getAppIdentityCredentials()
-  {
-    $class = new \ReflectionClass(
-      'Google\Auth\Credentials\AppIdentityCredentials'
-    );
-    $property = $class->getProperty('lastReceivedToken');
-    $property->setAccessible(true);
+    private function getAppIdentityCredentials()
+    {
+        $class = new \ReflectionClass(
+            'Google\Auth\Credentials\AppIdentityCredentials'
+        );
+        $property = $class->getProperty('lastReceivedToken');
+        $property->setAccessible(true);
 
-    $credentials = new AppIdentityCredentials();
-    $property->setValue($credentials, [
-      'access_token' => 'xyz',
-      'expiration_time' => strtotime('2001'),
-    ]);
+        $credentials = new AppIdentityCredentials();
+        $property->setValue($credentials, [
+            'access_token' => 'xyz',
+            'expiration_time' => strtotime('2001'),
+        ]);
 
-    return $credentials;
-  }
+        return $credentials;
+    }
 
-  private function getGCECredentials()
-  {
-    $class = new \ReflectionClass(
-      'Google\Auth\Credentials\GCECredentials'
-    );
-    $property = $class->getProperty('lastReceivedToken');
-    $property->setAccessible(true);
+    private function getGCECredentials()
+    {
+        $class = new \ReflectionClass(
+            'Google\Auth\Credentials\GCECredentials'
+        );
+        $property = $class->getProperty('lastReceivedToken');
+        $property->setAccessible(true);
 
-    $credentials = new GCECredentials();
-    $property->setValue($credentials, [
-      'access_token' => 'xyz',
-      'expires_at' => strtotime('2001'),
-    ]);
+        $credentials = new GCECredentials();
+        $property->setValue($credentials, [
+            'access_token' => 'xyz',
+            'expires_at' => strtotime('2001'),
+        ]);
 
-    return $credentials;
-  }
+        return $credentials;
+    }
 
-  private function getServiceAccountCredentials($scopes, $jsonPath)
-  {
-    $class = new \ReflectionClass(
-      'Google\Auth\Credentials\ServiceAccountCredentials'
-    );
-    $property = $class->getProperty('auth');
-    $property->setAccessible(true);
+    private function getServiceAccountCredentials($scopes, $jsonPath)
+    {
+        $class = new \ReflectionClass(
+            'Google\Auth\Credentials\ServiceAccountCredentials'
+        );
+        $property = $class->getProperty('auth');
+        $property->setAccessible(true);
 
-    $credentials = new ServiceAccountCredentials($scopes, $jsonPath);
-    $property->setValue($credentials, $this->getOAuth2Mock());
+        $credentials = new ServiceAccountCredentials($scopes, $jsonPath);
+        $property->setValue($credentials, $this->getOAuth2Mock());
 
-    return $credentials;
-  }
+        return $credentials;
+    }
 
-  private function getServiceAccountJwtAccessCredentials($jsonPath)
-  {
-    $class = new \ReflectionClass(
-      'Google\Auth\Credentials\ServiceAccountJwtAccessCredentials'
-    );
-    $property = $class->getProperty('auth');
-    $property->setAccessible(true);
+    private function getServiceAccountJwtAccessCredentials($jsonPath)
+    {
+        $class = new \ReflectionClass(
+            'Google\Auth\Credentials\ServiceAccountJwtAccessCredentials'
+        );
+        $property = $class->getProperty('auth');
+        $property->setAccessible(true);
 
-    $credentials = new ServiceAccountJwtAccessCredentials($jsonPath);
-    $property->setValue($credentials, $this->getOAuth2Mock());
+        $credentials = new ServiceAccountJwtAccessCredentials($jsonPath);
+        $property->setValue($credentials, $this->getOAuth2Mock());
 
-    return $credentials;
-  }
+        return $credentials;
+    }
 
-  private function getUserRefreshCredentials($scopes, $jsonPath)
-  {
-    $class = new \ReflectionClass(
-      'Google\Auth\Credentials\UserRefreshCredentials'
-    );
-    $property = $class->getProperty('auth');
-    $property->setAccessible(true);
+    private function getUserRefreshCredentials($scopes, $jsonPath)
+    {
+        $class = new \ReflectionClass(
+            'Google\Auth\Credentials\UserRefreshCredentials'
+        );
+        $property = $class->getProperty('auth');
+        $property->setAccessible(true);
 
-    $credentials = new UserRefreshCredentials($scopes, $jsonPath);
-    $property->setValue($credentials, $this->getOAuth2Mock());
+        $credentials = new UserRefreshCredentials($scopes, $jsonPath);
+        $property->setValue($credentials, $this->getOAuth2Mock());
 
-    return $credentials;
-  }
+        return $credentials;
+    }
 
-  private function getOAuth2()
-  {
-    $oauth = new OAuth2([
-      'access_token' => 'xyz',
-      'expires_at' => strtotime('2001'),
-    ]);
+    private function getOAuth2()
+    {
+        $oauth = new OAuth2([
+            'access_token' => 'xyz',
+            'expires_at' => strtotime('2001'),
+        ]);
 
-    return $oauth;
-  }
+        return $oauth;
+    }
 
-  private function getOAuth2Mock()
-  {
-    $mock = $this->getMockBuilder('Google\Auth\OAuth2')
-      ->disableOriginalConstructor()
-      ->getMock();
+    private function getOAuth2Mock()
+    {
+        $mock = $this->getMockBuilder('Google\Auth\OAuth2')
+            ->disableOriginalConstructor()
+            ->getMock();
 
-    $mock
-      ->expects($this->once())
-      ->method('getLastReceivedToken')
-      ->will($this->returnValue([
-        'access_token' => 'xyz',
-        'expires_at' => strtotime('2001'),
-      ]));
+        $mock
+            ->expects($this->once())
+            ->method('getLastReceivedToken')
+            ->will($this->returnValue([
+                'access_token' => 'xyz',
+                'expires_at' => strtotime('2001'),
+            ]));
 
-    return $mock;
-  }
+        return $mock;
+    }
 }

--- a/tests/HttpHandler/Guzzle5HttpHandlerTest.php
+++ b/tests/HttpHandler/Guzzle5HttpHandlerTest.php
@@ -18,43 +18,42 @@
 namespace Google\Auth\Tests;
 
 use Google\Auth\HttpHandler\Guzzle5HttpHandler;
-use GuzzleHttp\Client;
 use GuzzleHttp\Message\Response;
 
 class Guzzle5HttpHandlerTest extends BaseTest
 {
-  public function setUp()
-  {
-    $this->onlyGuzzle5();
+    public function setUp()
+    {
+        $this->onlyGuzzle5();
 
-    $this->mockPsr7Request =
-      $this
-      ->getMockBuilder('Psr\Http\Message\RequestInterface')
-      ->getMock();
-    $this->mockRequest =
-      $this
-      ->getMockBuilder('GuzzleHttp\Message\RequestInterface')
-      ->getMock();
-    $this->mockClient =
-      $this
-      ->getMockBuilder('GuzzleHttp\Client')
-      ->disableOriginalConstructor()
-      ->getMock();
-  }
+        $this->mockPsr7Request =
+            $this
+                ->getMockBuilder('Psr\Http\Message\RequestInterface')
+                ->getMock();
+        $this->mockRequest =
+            $this
+                ->getMockBuilder('GuzzleHttp\Message\RequestInterface')
+                ->getMock();
+        $this->mockClient =
+            $this
+                ->getMockBuilder('GuzzleHttp\Client')
+                ->disableOriginalConstructor()
+                ->getMock();
+    }
 
-  public function testSuccessfullySendsRequest()
-  {
-    $this->mockClient
-      ->expects($this->any())
-      ->method('send')
-      ->will($this->returnValue(new Response(200)));
-    $this->mockClient
-      ->expects($this->any())
-      ->method('createRequest')
-      ->will($this->returnValue($this->mockRequest));
+    public function testSuccessfullySendsRequest()
+    {
+        $this->mockClient
+            ->expects($this->any())
+            ->method('send')
+            ->will($this->returnValue(new Response(200)));
+        $this->mockClient
+            ->expects($this->any())
+            ->method('createRequest')
+            ->will($this->returnValue($this->mockRequest));
 
-    $handler = new Guzzle5HttpHandler($this->mockClient);
-    $response = $handler($this->mockPsr7Request);
-    $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
-  }
+        $handler = new Guzzle5HttpHandler($this->mockClient);
+        $response = $handler($this->mockPsr7Request);
+        $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
+    }
 }

--- a/tests/HttpHandler/Guzzle6HttpHandlerTest.php
+++ b/tests/HttpHandler/Guzzle6HttpHandlerTest.php
@@ -18,35 +18,33 @@
 namespace Google\Auth\Tests;
 
 use Google\Auth\HttpHandler\Guzzle6HttpHandler;
-use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Response;
-
 
 class Guzzle6HttpHandlerTest extends BaseTest
 {
-  public function setUp()
-  {
-    $this->onlyGuzzle6();
+    public function setUp()
+    {
+        $this->onlyGuzzle6();
 
-    $this->mockRequest =
-      $this
-      ->getMockBuilder('Psr\Http\Message\RequestInterface')
-      ->getMock();
-    $this->mockClient =
-      $this
-      ->getMockBuilder('GuzzleHttp\Client')
-      ->getMock();
-  }
+        $this->mockRequest =
+            $this
+                ->getMockBuilder('Psr\Http\Message\RequestInterface')
+                ->getMock();
+        $this->mockClient =
+            $this
+                ->getMockBuilder('GuzzleHttp\Client')
+                ->getMock();
+    }
 
-  public function testSuccessfullySendsRequest()
-  {
-    $this->mockClient
-      ->expects($this->any())
-      ->method('send')
-      ->will($this->returnValue(new Response(200)));
+    public function testSuccessfullySendsRequest()
+    {
+        $this->mockClient
+            ->expects($this->any())
+            ->method('send')
+            ->will($this->returnValue(new Response(200)));
 
-    $handler = new Guzzle6HttpHandler($this->mockClient);
-    $response = $handler($this->mockRequest);
-    $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
-  }
+        $handler = new Guzzle6HttpHandler($this->mockClient);
+        $response = $handler($this->mockRequest);
+        $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
+    }
 }

--- a/tests/HttpHandler/HttpHandlerFactoryTest.php
+++ b/tests/HttpHandler/HttpHandlerFactoryTest.php
@@ -21,19 +21,19 @@ use Google\Auth\HttpHandler\HttpHandlerFactory;
 
 class HttpHandlerFactoryTest extends BaseTest
 {
-  public function testBuildsGuzzle5Handler()
-  {
-    $this->onlyGuzzle5();
+    public function testBuildsGuzzle5Handler()
+    {
+        $this->onlyGuzzle5();
 
-    $handler = HttpHandlerFactory::build();
-    $this->assertInstanceOf('Google\Auth\HttpHandler\Guzzle5HttpHandler', $handler);
-  }
+        $handler = HttpHandlerFactory::build();
+        $this->assertInstanceOf('Google\Auth\HttpHandler\Guzzle5HttpHandler', $handler);
+    }
 
-  public function testBuildsGuzzle6Handler()
-  {
-    $this->onlyGuzzle6();
+    public function testBuildsGuzzle6Handler()
+    {
+        $this->onlyGuzzle6();
 
-    $handler = HttpHandlerFactory::build();
-    $this->assertInstanceOf('Google\Auth\HttpHandler\Guzzle6HttpHandler', $handler);
-  }
+        $handler = HttpHandlerFactory::build();
+        $this->assertInstanceOf('Google\Auth\HttpHandler\Guzzle6HttpHandler', $handler);
+    }
 }

--- a/tests/Middleware/AuthTokenMiddlewareTest.php
+++ b/tests/Middleware/AuthTokenMiddlewareTest.php
@@ -19,194 +19,193 @@ namespace Google\Auth\Tests;
 
 use Google\Auth\Middleware\AuthTokenMiddleware;
 use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 
 class AuthTokenMiddlewareTest extends BaseTest
 {
-  private $mockFetcher;
-  private $mockCache;
-  private $mockRequest;
+    private $mockFetcher;
+    private $mockCache;
+    private $mockRequest;
 
-  protected function setUp()
-  {
-    $this->onlyGuzzle6();
+    protected function setUp()
+    {
+        $this->onlyGuzzle6();
 
-    $this->mockFetcher =
-      $this
-      ->getMockBuilder('Google\Auth\FetchAuthTokenInterface')
-      ->getMock();
-    $this->mockCache =
-      $this
-      ->getMockBuilder('Google\Auth\CacheInterface')
-      ->getMock();
-    $this->mockRequest =
-      $this
-      ->getMockBuilder('GuzzleHttp\Psr7\Request')
-      ->disableOriginalConstructor()
-      ->getMock();
-  }
+        $this->mockFetcher =
+            $this
+                ->getMockBuilder('Google\Auth\FetchAuthTokenInterface')
+                ->getMock();
+        $this->mockCache =
+            $this
+                ->getMockBuilder('Google\Auth\CacheInterface')
+                ->getMock();
+        $this->mockRequest =
+            $this
+                ->getMockBuilder('GuzzleHttp\Psr7\Request')
+                ->disableOriginalConstructor()
+                ->getMock();
+    }
 
-  public function testOnlyTouchesWhenAuthConfigScoped()
-  {
-    $this->mockFetcher
-      ->expects($this->any())
-      ->method('fetchAuthToken')
-      ->will($this->returnValue([]));
-    $this->mockRequest
-      ->expects($this->never())
-      ->method('withHeader');
+    public function testOnlyTouchesWhenAuthConfigScoped()
+    {
+        $this->mockFetcher
+            ->expects($this->any())
+            ->method('fetchAuthToken')
+            ->will($this->returnValue([]));
+        $this->mockRequest
+            ->expects($this->never())
+            ->method('withHeader');
 
-    $middleware = new AuthTokenMiddleware($this->mockFetcher);
-    $mock = new MockHandler([new Response(200)]);
-    $callable = $middleware($mock);
-    $callable($this->mockRequest, ['auth' => 'not_google_auth']);
-  }
+        $middleware = new AuthTokenMiddleware($this->mockFetcher);
+        $mock = new MockHandler([new Response(200)]);
+        $callable = $middleware($mock);
+        $callable($this->mockRequest, ['auth' => 'not_google_auth']);
+    }
 
-  public function testAddsTheTokenAsAnAuthorizationHeader()
-  {
-    $authResult = ['access_token' => '1/abcdef1234567890'];
-    $this->mockFetcher
-        ->expects($this->once())
-        ->method('fetchAuthToken')
-        ->will($this->returnValue($authResult));
-    $this->mockRequest
-      ->expects($this->once())
-      ->method('withHeader')
-      ->with('Authorization', 'Bearer ' . $authResult['access_token'])
-      ->will($this->returnValue($this->mockRequest));
+    public function testAddsTheTokenAsAnAuthorizationHeader()
+    {
+        $authResult = ['access_token' => '1/abcdef1234567890'];
+        $this->mockFetcher
+            ->expects($this->once())
+            ->method('fetchAuthToken')
+            ->will($this->returnValue($authResult));
+        $this->mockRequest
+            ->expects($this->once())
+            ->method('withHeader')
+            ->with('Authorization', 'Bearer '.$authResult['access_token'])
+            ->will($this->returnValue($this->mockRequest));
 
-    // Run the test.
-    $middleware = new AuthTokenMiddleware($this->mockFetcher);
-    $mock = new MockHandler([new Response(200)]);
-    $callable = $middleware($mock);
-    $callable($this->mockRequest, ['auth' => 'google_auth']);
-  }
+        // Run the test.
+        $middleware = new AuthTokenMiddleware($this->mockFetcher);
+        $mock = new MockHandler([new Response(200)]);
+        $callable = $middleware($mock);
+        $callable($this->mockRequest, ['auth' => 'google_auth']);
+    }
 
-  public function testDoesNotAddAnAuthorizationHeaderOnNoAccessToken()
-  {
-    $authResult = ['not_access_token' => '1/abcdef1234567890'];
-    $this->mockFetcher
-        ->expects($this->once())
-        ->method('fetchAuthToken')
-        ->will($this->returnValue($authResult));
-    $this->mockRequest
-      ->expects($this->once())
-      ->method('withHeader')
-      ->with('Authorization', 'Bearer ')
-      ->will($this->returnValue($this->mockRequest));
+    public function testDoesNotAddAnAuthorizationHeaderOnNoAccessToken()
+    {
+        $authResult = ['not_access_token' => '1/abcdef1234567890'];
+        $this->mockFetcher
+            ->expects($this->once())
+            ->method('fetchAuthToken')
+            ->will($this->returnValue($authResult));
+        $this->mockRequest
+            ->expects($this->once())
+            ->method('withHeader')
+            ->with('Authorization', 'Bearer ')
+            ->will($this->returnValue($this->mockRequest));
 
-    // Run the test.
-    $middleware = new AuthTokenMiddleware($this->mockFetcher);
-    $mock = new MockHandler([new Response(200)]);
-    $callable = $middleware($mock);
-    $callable($this->mockRequest, ['auth' => 'google_auth']);
-  }
+        // Run the test.
+        $middleware = new AuthTokenMiddleware($this->mockFetcher);
+        $mock = new MockHandler([new Response(200)]);
+        $callable = $middleware($mock);
+        $callable($this->mockRequest, ['auth' => 'google_auth']);
+    }
 
-  public function testUsesCachedAuthToken()
-  {
-    $cacheKey = 'myKey';
-    $cachedValue = '2/abcdef1234567890';
-    $this->mockCache
-        ->expects($this->once())
-        ->method('get')
-        ->with($this->equalTo($cacheKey),
-               $this->equalTo(AuthTokenMiddleware::DEFAULT_CACHE_LIFETIME))
-        ->will($this->returnValue($cachedValue));
-    $this->mockFetcher
-        ->expects($this->never())
-        ->method('fetchAuthToken');
-    $this->mockFetcher
-        ->expects($this->any())
-        ->method('getCacheKey')
-        ->will($this->returnValue($cacheKey));
-    $this->mockRequest
-      ->expects($this->once())
-      ->method('withHeader')
-      ->with('Authorization', 'Bearer ' . $cachedValue)
-      ->will($this->returnValue($this->mockRequest));
+    public function testUsesCachedAuthToken()
+    {
+        $cacheKey = 'myKey';
+        $cachedValue = '2/abcdef1234567890';
+        $this->mockCache
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo($cacheKey),
+                $this->equalTo(AuthTokenMiddleware::DEFAULT_CACHE_LIFETIME))
+            ->will($this->returnValue($cachedValue));
+        $this->mockFetcher
+            ->expects($this->never())
+            ->method('fetchAuthToken');
+        $this->mockFetcher
+            ->expects($this->any())
+            ->method('getCacheKey')
+            ->will($this->returnValue($cacheKey));
+        $this->mockRequest
+            ->expects($this->once())
+            ->method('withHeader')
+            ->with('Authorization', 'Bearer '.$cachedValue)
+            ->will($this->returnValue($this->mockRequest));
 
-    // Run the test.
-    $middleware = new AuthTokenMiddleware($this->mockFetcher, [], $this->mockCache);
-    $mock = new MockHandler([new Response(200)]);
-    $callable = $middleware($mock);
-    $callable($this->mockRequest, ['auth' => 'google_auth']);
-  }
+        // Run the test.
+        $middleware = new AuthTokenMiddleware($this->mockFetcher, [], $this->mockCache);
+        $mock = new MockHandler([new Response(200)]);
+        $callable = $middleware($mock);
+        $callable($this->mockRequest, ['auth' => 'google_auth']);
+    }
 
-  public function testGetsCachedAuthTokenUsingCacheOptions()
-  {
-    $prefix = 'test_prefix:';
-    $lifetime = '70707';
-    $cacheKey = 'myKey';
-    $cachedValue = '2/abcdef1234567890';
-    $this->mockCache
-        ->expects($this->once())
-        ->method('get')
-        ->with($this->equalTo($prefix . $cacheKey),
-               $this->equalTo($lifetime))
-        ->will($this->returnValue($cachedValue));
-    $this->mockFetcher
-        ->expects($this->never())
-        ->method('fetchAuthToken');
-    $this->mockFetcher
-        ->expects($this->any())
-        ->method('getCacheKey')
-        ->will($this->returnValue($cacheKey));
-    $this->mockRequest
-      ->expects($this->once())
-      ->method('withHeader')
-      ->with('Authorization', 'Bearer ' . $cachedValue)
-      ->will($this->returnValue($this->mockRequest));
+    public function testGetsCachedAuthTokenUsingCacheOptions()
+    {
+        $prefix = 'test_prefix:';
+        $lifetime = '70707';
+        $cacheKey = 'myKey';
+        $cachedValue = '2/abcdef1234567890';
+        $this->mockCache
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo($prefix.$cacheKey),
+                $this->equalTo($lifetime))
+            ->will($this->returnValue($cachedValue));
+        $this->mockFetcher
+            ->expects($this->never())
+            ->method('fetchAuthToken');
+        $this->mockFetcher
+            ->expects($this->any())
+            ->method('getCacheKey')
+            ->will($this->returnValue($cacheKey));
+        $this->mockRequest
+            ->expects($this->once())
+            ->method('withHeader')
+            ->with('Authorization', 'Bearer '.$cachedValue)
+            ->will($this->returnValue($this->mockRequest));
 
-    // Run the test.
-    $middleware = new AuthTokenMiddleware(
-      $this->mockFetcher,
-      ['prefix' => $prefix, 'lifetime' => $lifetime],
-      $this->mockCache
-    );
-    $mock = new MockHandler([new Response(200)]);
-    $callable = $middleware($mock);
-    $callable($this->mockRequest, ['auth' => 'google_auth']);
-  }
+        // Run the test.
+        $middleware = new AuthTokenMiddleware(
+            $this->mockFetcher,
+            ['prefix' => $prefix, 'lifetime' => $lifetime],
+            $this->mockCache
+        );
+        $mock = new MockHandler([new Response(200)]);
+        $callable = $middleware($mock);
+        $callable($this->mockRequest, ['auth' => 'google_auth']);
+    }
 
-  public function testShouldSaveValueInCacheWithSpecifiedPrefix()
-  {
-    $token = '1/abcdef1234567890';
-    $authResult = ['access_token' => $token];
-    $cacheKey = 'myKey';
-    $prefix = 'test_prefix:';
-    $this->mockCache
-        ->expects($this->any())
-        ->method('get')
-        ->will($this->returnValue(null));
-    $this->mockCache
-        ->expects($this->once())
-        ->method('set')
-        ->with($this->equalTo($prefix . $cacheKey),
-               $this->equalTo($token))
-        ->will($this->returnValue(false));
-    $this->mockFetcher
-        ->expects($this->any())
-        ->method('getCacheKey')
-        ->will($this->returnValue($cacheKey));
-    $this->mockFetcher
-        ->expects($this->once())
-        ->method('fetchAuthToken')
-        ->will($this->returnValue($authResult));
-    $this->mockRequest
-      ->expects($this->once())
-      ->method('withHeader')
-      ->with('Authorization', 'Bearer ' . $token)
-      ->will($this->returnValue($this->mockRequest));
+    public function testShouldSaveValueInCacheWithSpecifiedPrefix()
+    {
+        $token = '1/abcdef1234567890';
+        $authResult = ['access_token' => $token];
+        $cacheKey = 'myKey';
+        $prefix = 'test_prefix:';
+        $this->mockCache
+            ->expects($this->any())
+            ->method('get')
+            ->will($this->returnValue(null));
+        $this->mockCache
+            ->expects($this->once())
+            ->method('set')
+            ->with($this->equalTo($prefix.$cacheKey),
+                $this->equalTo($token))
+            ->will($this->returnValue(false));
+        $this->mockFetcher
+            ->expects($this->any())
+            ->method('getCacheKey')
+            ->will($this->returnValue($cacheKey));
+        $this->mockFetcher
+            ->expects($this->once())
+            ->method('fetchAuthToken')
+            ->will($this->returnValue($authResult));
+        $this->mockRequest
+            ->expects($this->once())
+            ->method('withHeader')
+            ->with('Authorization', 'Bearer '.$token)
+            ->will($this->returnValue($this->mockRequest));
 
-    // Run the test.
-    $middleware = new AuthTokenMiddleware(
-      $this->mockFetcher,
-      ['prefix' => $prefix],
-      $this->mockCache
-    );
-    $mock = new MockHandler([new Response(200)]);
-    $callable = $middleware($mock);
-    $callable($this->mockRequest, ['auth' => 'google_auth']);
-  }
+        // Run the test.
+        $middleware = new AuthTokenMiddleware(
+            $this->mockFetcher,
+            ['prefix' => $prefix],
+            $this->mockCache
+        );
+        $mock = new MockHandler([new Response(200)]);
+        $callable = $middleware($mock);
+        $callable($this->mockRequest, ['auth' => 'google_auth']);
+    }
 }

--- a/tests/Middleware/ScopedAccessTokenMiddlewareTest.php
+++ b/tests/Middleware/ScopedAccessTokenMiddlewareTest.php
@@ -19,202 +19,201 @@ namespace Google\Auth\Tests;
 
 use Google\Auth\Middleware\ScopedAccessTokenMiddleware;
 use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 
 class ScopedAccessTokenMiddlewareTest extends BaseTest
 {
-  const TEST_SCOPE = 'https://www.googleapis.com/auth/cloud-taskqueue';
+    const TEST_SCOPE = 'https://www.googleapis.com/auth/cloud-taskqueue';
 
-  private $mockCache;
-  private $mockRequest;
+    private $mockCache;
+    private $mockRequest;
 
-  protected function setUp()
-  {
-    $this->onlyGuzzle6();
+    protected function setUp()
+    {
+        $this->onlyGuzzle6();
 
-    $this->mockCache =
-      $this
-      ->getMockBuilder('Google\Auth\CacheInterface')
-      ->getMock();
-    $this->mockRequest =
-      $this
-      ->getMockBuilder('GuzzleHttp\Psr7\Request')
-      ->disableOriginalConstructor()
-      ->getMock();
-  }
+        $this->mockCache =
+            $this
+                ->getMockBuilder('Google\Auth\CacheInterface')
+                ->getMock();
+        $this->mockRequest =
+            $this
+                ->getMockBuilder('GuzzleHttp\Psr7\Request')
+                ->disableOriginalConstructor()
+                ->getMock();
+    }
 
-  /**
-   * @expectedException InvalidArgumentException
-   */
-  public function testRequiresScopeAsAStringOrArray()
-  {
-    $fakeAuthFunc = function ($unused_scopes) {
-       return '1/abcdef1234567890';
-    };
-    new ScopedAccessTokenMiddleware($fakeAuthFunc, new \stdClass());
-  }
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testRequiresScopeAsAStringOrArray()
+    {
+        $fakeAuthFunc = function ($unused_scopes) {
+            return '1/abcdef1234567890';
+        };
+        new ScopedAccessTokenMiddleware($fakeAuthFunc, new \stdClass());
+    }
 
-  public function testAddsTheTokenAsAnAuthorizationHeader()
-  {
-    $token = '1/abcdef1234567890';
-    $fakeAuthFunc = function ($unused_scopes) use ($token) {
-       return $token;
-    };
-    $this->mockRequest
-      ->expects($this->once())
-      ->method('withHeader')
-      ->with('Authorization', 'Bearer ' . $token)
-      ->will($this->returnValue($this->mockRequest));
+    public function testAddsTheTokenAsAnAuthorizationHeader()
+    {
+        $token = '1/abcdef1234567890';
+        $fakeAuthFunc = function ($unused_scopes) use ($token) {
+            return $token;
+        };
+        $this->mockRequest
+            ->expects($this->once())
+            ->method('withHeader')
+            ->with('Authorization', 'Bearer '.$token)
+            ->will($this->returnValue($this->mockRequest));
 
-    // Run the test
-    $middleware = new ScopedAccessTokenMiddleware($fakeAuthFunc, self::TEST_SCOPE);
-    $mock = new MockHandler([new Response(200)]);
-    $callable = $middleware($mock);
-    $callable($this->mockRequest, ['auth' => 'scoped']);
-  }
+        // Run the test
+        $middleware = new ScopedAccessTokenMiddleware($fakeAuthFunc, self::TEST_SCOPE);
+        $mock = new MockHandler([new Response(200)]);
+        $callable = $middleware($mock);
+        $callable($this->mockRequest, ['auth' => 'scoped']);
+    }
 
-  public function testUsesCachedAuthToken()
-  {
-    $cachedValue = '2/abcdef1234567890';
-    $fakeAuthFunc = function ($unused_scopes) {
-       return '';
-    };
-    $this->mockCache
-        ->expects($this->once())
-        ->method('get')
-        ->will($this->returnValue($cachedValue));
-    $this->mockRequest
-      ->expects($this->once())
-      ->method('withHeader')
-      ->with('Authorization', 'Bearer ' . $cachedValue)
-      ->will($this->returnValue($this->mockRequest));
+    public function testUsesCachedAuthToken()
+    {
+        $cachedValue = '2/abcdef1234567890';
+        $fakeAuthFunc = function ($unused_scopes) {
+            return '';
+        };
+        $this->mockCache
+            ->expects($this->once())
+            ->method('get')
+            ->will($this->returnValue($cachedValue));
+        $this->mockRequest
+            ->expects($this->once())
+            ->method('withHeader')
+            ->with('Authorization', 'Bearer '.$cachedValue)
+            ->will($this->returnValue($this->mockRequest));
 
-    // Run the test
-    $middleware = new ScopedAccessTokenMiddleware(
-      $fakeAuthFunc,
-      self::TEST_SCOPE,
-      [],
-      $this->mockCache
-    );
-    $mock = new MockHandler([new Response(200)]);
-    $callable = $middleware($mock);
-    $callable($this->mockRequest, ['auth' => 'scoped']);
-  }
+        // Run the test
+        $middleware = new ScopedAccessTokenMiddleware(
+            $fakeAuthFunc,
+            self::TEST_SCOPE,
+            [],
+            $this->mockCache
+        );
+        $mock = new MockHandler([new Response(200)]);
+        $callable = $middleware($mock);
+        $callable($this->mockRequest, ['auth' => 'scoped']);
+    }
 
-  public function testGetsCachedAuthTokenUsingCacheOptions()
-  {
-    $prefix = 'test_prefix:';
-    $lifetime = '70707';
-    $cachedValue = '2/abcdef1234567890';
-    $fakeAuthFunc = function ($unused_scopes) {
-       return '';
-    };
-    $this->mockCache
-        ->expects($this->once())
-        ->method('get')
-        ->with($this->equalTo($prefix . self::TEST_SCOPE),
-               $this->equalTo($lifetime))
-        ->will($this->returnValue($cachedValue));
-    $this->mockRequest
-      ->expects($this->once())
-      ->method('withHeader')
-      ->with('Authorization', 'Bearer ' . $cachedValue)
-      ->will($this->returnValue($this->mockRequest));
+    public function testGetsCachedAuthTokenUsingCacheOptions()
+    {
+        $prefix = 'test_prefix:';
+        $lifetime = '70707';
+        $cachedValue = '2/abcdef1234567890';
+        $fakeAuthFunc = function ($unused_scopes) {
+            return '';
+        };
+        $this->mockCache
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo($prefix.self::TEST_SCOPE),
+                $this->equalTo($lifetime))
+            ->will($this->returnValue($cachedValue));
+        $this->mockRequest
+            ->expects($this->once())
+            ->method('withHeader')
+            ->with('Authorization', 'Bearer '.$cachedValue)
+            ->will($this->returnValue($this->mockRequest));
 
-    // Run the test
-    $middleware = new ScopedAccessTokenMiddleware(
-      $fakeAuthFunc,
-      self::TEST_SCOPE,
-      ['prefix' => $prefix, 'lifetime' => $lifetime],
-      $this->mockCache
-    );
-    $mock = new MockHandler([new Response(200)]);
-    $callable = $middleware($mock);
-    $callable($this->mockRequest, ['auth' => 'scoped']);
-  }
+        // Run the test
+        $middleware = new ScopedAccessTokenMiddleware(
+            $fakeAuthFunc,
+            self::TEST_SCOPE,
+            ['prefix' => $prefix, 'lifetime' => $lifetime],
+            $this->mockCache
+        );
+        $mock = new MockHandler([new Response(200)]);
+        $callable = $middleware($mock);
+        $callable($this->mockRequest, ['auth' => 'scoped']);
+    }
 
-  public function testShouldSaveValueInCache()
-  {
-    $token = '2/abcdef1234567890';
-    $fakeAuthFunc = function ($unused_scopes) use ($token) {
-       return $token;
-    };
-    $this->mockCache
-        ->expects($this->once())
-        ->method('get')
-        ->will($this->returnValue(false));
-    $this->mockCache
-        ->expects($this->once())
-        ->method('set')
-        ->with($this->equalTo(self::TEST_SCOPE), $this->equalTo($token))
-        ->will($this->returnValue(false));
-    $this->mockRequest
-      ->expects($this->once())
-      ->method('withHeader')
-      ->with('Authorization', 'Bearer ' . $token)
-      ->will($this->returnValue($this->mockRequest));
+    public function testShouldSaveValueInCache()
+    {
+        $token = '2/abcdef1234567890';
+        $fakeAuthFunc = function ($unused_scopes) use ($token) {
+            return $token;
+        };
+        $this->mockCache
+            ->expects($this->once())
+            ->method('get')
+            ->will($this->returnValue(false));
+        $this->mockCache
+            ->expects($this->once())
+            ->method('set')
+            ->with($this->equalTo(self::TEST_SCOPE), $this->equalTo($token))
+            ->will($this->returnValue(false));
+        $this->mockRequest
+            ->expects($this->once())
+            ->method('withHeader')
+            ->with('Authorization', 'Bearer '.$token)
+            ->will($this->returnValue($this->mockRequest));
 
-    // Run the test
-    $middleware = new ScopedAccessTokenMiddleware(
-      $fakeAuthFunc,
-      self::TEST_SCOPE,
-      [],
-      $this->mockCache
-    );
-    $mock = new MockHandler([new Response(200)]);
-    $callable = $middleware($mock);
-    $callable($this->mockRequest, ['auth' => 'scoped']);
-  }
+        // Run the test
+        $middleware = new ScopedAccessTokenMiddleware(
+            $fakeAuthFunc,
+            self::TEST_SCOPE,
+            [],
+            $this->mockCache
+        );
+        $mock = new MockHandler([new Response(200)]);
+        $callable = $middleware($mock);
+        $callable($this->mockRequest, ['auth' => 'scoped']);
+    }
 
-  public function testShouldSaveValueInCacheWithSpecifiedPrefix()
-  {
-    $token = '2/abcdef1234567890';
-    $prefix = 'test_prefix:';
-    $fakeAuthFunc = function ($unused_scopes) use ($token) {
-       return $token;
-    };
-    $this->mockCache
-        ->expects($this->once())
-        ->method('get')
-        ->will($this->returnValue(false));
-    $this->mockCache
-        ->expects($this->once())
-        ->method('set')
-        ->with($this->equalTo($prefix . self::TEST_SCOPE),
-               $this->equalTo($token))
-        ->will($this->returnValue(false));
-    $this->mockRequest
-      ->expects($this->once())
-      ->method('withHeader')
-      ->with('Authorization', 'Bearer ' . $token)
-      ->will($this->returnValue($this->mockRequest));
+    public function testShouldSaveValueInCacheWithSpecifiedPrefix()
+    {
+        $token = '2/abcdef1234567890';
+        $prefix = 'test_prefix:';
+        $fakeAuthFunc = function ($unused_scopes) use ($token) {
+            return $token;
+        };
+        $this->mockCache
+            ->expects($this->once())
+            ->method('get')
+            ->will($this->returnValue(false));
+        $this->mockCache
+            ->expects($this->once())
+            ->method('set')
+            ->with($this->equalTo($prefix.self::TEST_SCOPE),
+                $this->equalTo($token))
+            ->will($this->returnValue(false));
+        $this->mockRequest
+            ->expects($this->once())
+            ->method('withHeader')
+            ->with('Authorization', 'Bearer '.$token)
+            ->will($this->returnValue($this->mockRequest));
 
-    // Run the test
-    $middleware = new ScopedAccessTokenMiddleware(
-      $fakeAuthFunc,
-      self::TEST_SCOPE,
-      ['prefix' => $prefix],
-      $this->mockCache
-    );
-    $mock = new MockHandler([new Response(200)]);
-    $callable = $middleware($mock);
-    $callable($this->mockRequest, ['auth' => 'scoped']);
-  }
+        // Run the test
+        $middleware = new ScopedAccessTokenMiddleware(
+            $fakeAuthFunc,
+            self::TEST_SCOPE,
+            ['prefix' => $prefix],
+            $this->mockCache
+        );
+        $mock = new MockHandler([new Response(200)]);
+        $callable = $middleware($mock);
+        $callable($this->mockRequest, ['auth' => 'scoped']);
+    }
 
-  public function testOnlyTouchesWhenAuthConfigScoped()
-  {
-    $fakeAuthFunc = function ($unused_scopes) {
-       return '1/abcdef1234567890';
-    };
-    $this->mockRequest
-      ->expects($this->never())
-      ->method('withHeader');
+    public function testOnlyTouchesWhenAuthConfigScoped()
+    {
+        $fakeAuthFunc = function ($unused_scopes) {
+            return '1/abcdef1234567890';
+        };
+        $this->mockRequest
+            ->expects($this->never())
+            ->method('withHeader');
 
-    // Run the test
-    $middleware = new ScopedAccessTokenMiddleware($fakeAuthFunc, self::TEST_SCOPE);
-    $mock = new MockHandler([new Response(200)]);
-    $callable = $middleware($mock);
-    $callable($this->mockRequest, ['auth' => 'not_scoped']);
-  }
+        // Run the test
+        $middleware = new ScopedAccessTokenMiddleware($fakeAuthFunc, self::TEST_SCOPE);
+        $mock = new MockHandler([new Response(200)]);
+        $callable = $middleware($mock);
+        $callable($this->mockRequest, ['auth' => 'not_scoped']);
+    }
 }

--- a/tests/Middleware/SimpleMiddlewareTest.php
+++ b/tests/Middleware/SimpleMiddlewareTest.php
@@ -17,32 +17,25 @@
 
 namespace Google\Auth\Tests;
 
-use Google\Auth\Middleware\SimpleMiddleware;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\Psr7\Request;
-use GuzzleHttp\Psr7\Response;
-use GuzzleHttp\Psr7\Uri;
-
 class SimpleMiddlewareTest extends BaseTest
 {
-  private $mockRequest;
+    private $mockRequest;
 
-  /**
-   * @todo finish
-   */
-  protected function setUp()
-  {
-    $this->onlyGuzzle6();
+    /**
+     * @todo finish
+     */
+    protected function setUp()
+    {
+        $this->onlyGuzzle6();
 
-    $this->mockRequest =
-      $this
-      ->getMockBuilder('GuzzleHttp\Psr7\Request')
-      ->disableOriginalConstructor()
-      ->getMock();
-  }
+        $this->mockRequest =
+            $this
+                ->getMockBuilder('GuzzleHttp\Psr7\Request')
+                ->disableOriginalConstructor()
+                ->getMock();
+    }
 
-  public function testTest()
-  {
-
-  }
+    public function testTest()
+    {
+    }
 }

--- a/tests/OAuth2Test.php
+++ b/tests/OAuth2Test.php
@@ -17,815 +17,811 @@
 
 namespace Google\Auth\Tests;
 
-use Google\Auth\HttpHandler\Guzzle6HttpHandler;
 use Google\Auth\OAuth2;
-use GuzzleHttp\Client;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Response;
 
 class OAuth2AuthorizationUriTest extends \PHPUnit_Framework_TestCase
 {
-
-  private $minimal = [
-      'authorizationUri' => 'https://accounts.test.org/insecure/url',
-      'redirectUri' => 'https://accounts.test.org/redirect/url',
-      'clientId' => 'aClientID'
-  ];
-
-  /**
-   * @expectedException InvalidArgumentException
-   */
-  public function testIsNullIfAuthorizationUriIsNull()
-  {
-    $o = new OAuth2([]);
-    $this->assertNull($o->buildFullAuthorizationUri());
-  }
-
-  /**
-   * @expectedException InvalidArgumentException
-   */
-  public function testRequiresTheClientId()
-  {
-    $o = new OAuth2([
-        'authorizationUri' => 'https://accounts.test.org/auth/url',
-        'redirectUri' => 'https://accounts.test.org/redirect/url'
-    ]);
-    $o->buildFullAuthorizationUri();
-  }
-
-  /**
-   * @expectedException InvalidArgumentException
-   */
-  public function testRequiresTheRedirectUri()
-  {
-    $o = new OAuth2([
-        'authorizationUri' => 'https://accounts.test.org/auth/url',
-        'clientId' => 'aClientID'
-    ]);
-    $o->buildFullAuthorizationUri();
-  }
-
-  /**
-   * @expectedException InvalidArgumentException
-   */
-  public function testCannotHavePromptAndApprovalPrompt()
-  {
-    $o = new OAuth2([
-        'authorizationUri' => 'https://accounts.test.org/auth/url',
-        'clientId' => 'aClientID'
-    ]);
-    $o->buildFullAuthorizationUri([
-        'approval_prompt' => 'an approval prompt',
-        'prompt' => 'a prompt',
-    ]);
-  }
-
-  /**
-   * @expectedException InvalidArgumentException
-   */
-  public function testCannotHaveInsecureAuthorizationUri()
-  {
-    $o = new OAuth2([
-        'authorizationUri' => 'http://accounts.test.org/insecure/url',
-        'redirectUri' => 'https://accounts.test.org/redirect/url',
-        'clientId' => 'aClientID'
-    ]);
-    $o->buildFullAuthorizationUri();
-  }
-
-  /**
-   * @expectedException InvalidArgumentException
-   */
-  public function testCannotHaveRelativeRedirectUri()
-  {
-    $o = new OAuth2([
-        'authorizationUri' => 'http://accounts.test.org/insecure/url',
-        'redirectUri' => '/redirect/url',
-        'clientId' => 'aClientID'
-    ]);
-    $o->buildFullAuthorizationUri();
-  }
-
-  public function testHasDefaultXXXTypeParams()
-  {
-    $o = new OAuth2($this->minimal);
-    $q = Psr7\parse_query($o->buildFullAuthorizationUri()->getQuery());
-    $this->assertEquals('code', $q['response_type']);
-    $this->assertEquals('offline', $q['access_type']);
-  }
-
-  public function testCanBeUrlObject()
-  {
-    $config = array_merge($this->minimal, [
-        'authorizationUri' => Psr7\uri_for('https://another/uri')
-    ]);
-    $o = new OAuth2($config);
-    $this->assertEquals('/uri', $o->buildFullAuthorizationUri()->getPath());
-  }
-
-  public function testCanOverrideParams()
-  {
-    $overrides = [
-        'access_type' => 'o_access_type',
-        'client_id' => 'o_client_id',
-        'redirect_uri' => 'o_redirect_uri',
-        'response_type' => 'o_response_type',
-        'state' => 'o_state',
-    ];
-    $config = array_merge($this->minimal, ['state' => 'the_state']);
-    $o = new OAuth2($config);
-    $q = Psr7\parse_query($o->buildFullAuthorizationUri($overrides)->getQuery());
-    $this->assertEquals('o_access_type', $q['access_type']);
-    $this->assertEquals('o_client_id', $q['client_id']);
-    $this->assertEquals('o_redirect_uri', $q['redirect_uri']);
-    $this->assertEquals('o_response_type', $q['response_type']);
-    $this->assertEquals('o_state', $q['state']);
-  }
-
-  public function testIncludesTheScope()
-  {
-    $with_strings = array_merge($this->minimal, ['scope' => 'scope1 scope2']);
-    $o = new OAuth2($with_strings);
-    $q = Psr7\parse_query($o->buildFullAuthorizationUri()->getQuery());
-    $this->assertEquals('scope1 scope2', $q['scope']);
-
-    $with_array = array_merge($this->minimal, [
-        'scope' => ['scope1', 'scope2']
-    ]);
-    $o = new OAuth2($with_array);
-    $q = Psr7\parse_query($o->buildFullAuthorizationUri()->getQuery());
-    $this->assertEquals('scope1 scope2', $q['scope']);
-  }
-
-  public function testRedirectUriPostmessageIsAllowed()
-  {
-    $o = new OAuth2([
+    private $minimal = [
         'authorizationUri' => 'https://accounts.test.org/insecure/url',
-        'redirectUri' => 'postmessage',
-        'clientId' => 'aClientID'
-    ]);
-    $this->assertEquals('postmessage', $o->getRedirectUri());
-    $url = $o->buildFullAuthorizationUri();
-    $parts = parse_url((string) $url);
-    parse_str($parts['query'], $query);
-    $this->assertArrayHasKey('redirect_uri', $query);
-    $this->assertEquals('postmessage', $query['redirect_uri']);
-  }
+        'redirectUri' => 'https://accounts.test.org/redirect/url',
+        'clientId' => 'aClientID',
+    ];
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testIsNullIfAuthorizationUriIsNull()
+    {
+        $o = new OAuth2([]);
+        $this->assertNull($o->buildFullAuthorizationUri());
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testRequiresTheClientId()
+    {
+        $o = new OAuth2([
+            'authorizationUri' => 'https://accounts.test.org/auth/url',
+            'redirectUri' => 'https://accounts.test.org/redirect/url',
+        ]);
+        $o->buildFullAuthorizationUri();
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testRequiresTheRedirectUri()
+    {
+        $o = new OAuth2([
+            'authorizationUri' => 'https://accounts.test.org/auth/url',
+            'clientId' => 'aClientID',
+        ]);
+        $o->buildFullAuthorizationUri();
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testCannotHavePromptAndApprovalPrompt()
+    {
+        $o = new OAuth2([
+            'authorizationUri' => 'https://accounts.test.org/auth/url',
+            'clientId' => 'aClientID',
+        ]);
+        $o->buildFullAuthorizationUri([
+            'approval_prompt' => 'an approval prompt',
+            'prompt' => 'a prompt',
+        ]);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testCannotHaveInsecureAuthorizationUri()
+    {
+        $o = new OAuth2([
+            'authorizationUri' => 'http://accounts.test.org/insecure/url',
+            'redirectUri' => 'https://accounts.test.org/redirect/url',
+            'clientId' => 'aClientID',
+        ]);
+        $o->buildFullAuthorizationUri();
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testCannotHaveRelativeRedirectUri()
+    {
+        $o = new OAuth2([
+            'authorizationUri' => 'http://accounts.test.org/insecure/url',
+            'redirectUri' => '/redirect/url',
+            'clientId' => 'aClientID',
+        ]);
+        $o->buildFullAuthorizationUri();
+    }
+
+    public function testHasDefaultXXXTypeParams()
+    {
+        $o = new OAuth2($this->minimal);
+        $q = Psr7\parse_query($o->buildFullAuthorizationUri()->getQuery());
+        $this->assertEquals('code', $q['response_type']);
+        $this->assertEquals('offline', $q['access_type']);
+    }
+
+    public function testCanBeUrlObject()
+    {
+        $config = array_merge($this->minimal, [
+            'authorizationUri' => Psr7\uri_for('https://another/uri'),
+        ]);
+        $o = new OAuth2($config);
+        $this->assertEquals('/uri', $o->buildFullAuthorizationUri()->getPath());
+    }
+
+    public function testCanOverrideParams()
+    {
+        $overrides = [
+            'access_type' => 'o_access_type',
+            'client_id' => 'o_client_id',
+            'redirect_uri' => 'o_redirect_uri',
+            'response_type' => 'o_response_type',
+            'state' => 'o_state',
+        ];
+        $config = array_merge($this->minimal, ['state' => 'the_state']);
+        $o = new OAuth2($config);
+        $q = Psr7\parse_query($o->buildFullAuthorizationUri($overrides)->getQuery());
+        $this->assertEquals('o_access_type', $q['access_type']);
+        $this->assertEquals('o_client_id', $q['client_id']);
+        $this->assertEquals('o_redirect_uri', $q['redirect_uri']);
+        $this->assertEquals('o_response_type', $q['response_type']);
+        $this->assertEquals('o_state', $q['state']);
+    }
+
+    public function testIncludesTheScope()
+    {
+        $with_strings = array_merge($this->minimal, ['scope' => 'scope1 scope2']);
+        $o = new OAuth2($with_strings);
+        $q = Psr7\parse_query($o->buildFullAuthorizationUri()->getQuery());
+        $this->assertEquals('scope1 scope2', $q['scope']);
+
+        $with_array = array_merge($this->minimal, [
+            'scope' => ['scope1', 'scope2'],
+        ]);
+        $o = new OAuth2($with_array);
+        $q = Psr7\parse_query($o->buildFullAuthorizationUri()->getQuery());
+        $this->assertEquals('scope1 scope2', $q['scope']);
+    }
+
+    public function testRedirectUriPostmessageIsAllowed()
+    {
+        $o = new OAuth2([
+            'authorizationUri' => 'https://accounts.test.org/insecure/url',
+            'redirectUri' => 'postmessage',
+            'clientId' => 'aClientID',
+        ]);
+        $this->assertEquals('postmessage', $o->getRedirectUri());
+        $url = $o->buildFullAuthorizationUri();
+        $parts = parse_url((string)$url);
+        parse_str($parts['query'], $query);
+        $this->assertArrayHasKey('redirect_uri', $query);
+        $this->assertEquals('postmessage', $query['redirect_uri']);
+    }
 }
 
 class OAuth2GrantTypeTest extends \PHPUnit_Framework_TestCase
 {
-  private $minimal = [
-      'authorizationUri' => 'https://accounts.test.org/insecure/url',
-      'redirectUri' => 'https://accounts.test.org/redirect/url',
-      'clientId' => 'aClientID'
-  ];
+    private $minimal = [
+        'authorizationUri' => 'https://accounts.test.org/insecure/url',
+        'redirectUri' => 'https://accounts.test.org/redirect/url',
+        'clientId' => 'aClientID',
+    ];
 
-  public function testReturnsNullIfCannotBeInferred()
-  {
-    $o = new OAuth2($this->minimal);
-    $this->assertNull($o->getGrantType());
-  }
-
-  public function testInfersAuthorizationCode()
-  {
-    $o = new OAuth2($this->minimal);
-    $o->setCode('an auth code');
-    $this->assertEquals('authorization_code', $o->getGrantType());
-  }
-
-  public function testInfersRefreshToken()
-  {
-    $o = new OAuth2($this->minimal);
-    $o->setRefreshToken('a refresh token');
-    $this->assertEquals('refresh_token', $o->getGrantType());
-  }
-
-  public function testInfersPassword()
-  {
-    $o = new OAuth2($this->minimal);
-    $o->setPassword('a password');
-    $o->setUsername('a username');
-    $this->assertEquals('password', $o->getGrantType());
-  }
-
-  public function testInfersJwtBearer()
-  {
-    $o = new OAuth2($this->minimal);
-    $o->setIssuer('an issuer');
-    $o->setSigningKey('a key');
-    $this->assertEquals('urn:ietf:params:oauth:grant-type:jwt-bearer',
-                        $o->getGrantType());
-  }
-
-  public function testSetsKnownTypes()
-  {
-    $o = new OAuth2($this->minimal);
-    foreach (OAuth2::$knownGrantTypes as $t) {
-      $o->setGrantType($t);
-      $this->assertEquals($t, $o->getGrantType());
+    public function testReturnsNullIfCannotBeInferred()
+    {
+        $o = new OAuth2($this->minimal);
+        $this->assertNull($o->getGrantType());
     }
-  }
 
-  public function testSetsUrlAsGrantType()
-  {
-    $o = new OAuth2($this->minimal);
-    $o->setGrantType('http://a/grant/url');
-    $this->assertEquals('http://a/grant/url', $o->getGrantType());
-  }
+    public function testInfersAuthorizationCode()
+    {
+        $o = new OAuth2($this->minimal);
+        $o->setCode('an auth code');
+        $this->assertEquals('authorization_code', $o->getGrantType());
+    }
+
+    public function testInfersRefreshToken()
+    {
+        $o = new OAuth2($this->minimal);
+        $o->setRefreshToken('a refresh token');
+        $this->assertEquals('refresh_token', $o->getGrantType());
+    }
+
+    public function testInfersPassword()
+    {
+        $o = new OAuth2($this->minimal);
+        $o->setPassword('a password');
+        $o->setUsername('a username');
+        $this->assertEquals('password', $o->getGrantType());
+    }
+
+    public function testInfersJwtBearer()
+    {
+        $o = new OAuth2($this->minimal);
+        $o->setIssuer('an issuer');
+        $o->setSigningKey('a key');
+        $this->assertEquals('urn:ietf:params:oauth:grant-type:jwt-bearer',
+            $o->getGrantType());
+    }
+
+    public function testSetsKnownTypes()
+    {
+        $o = new OAuth2($this->minimal);
+        foreach (OAuth2::$knownGrantTypes as $t) {
+            $o->setGrantType($t);
+            $this->assertEquals($t, $o->getGrantType());
+        }
+    }
+
+    public function testSetsUrlAsGrantType()
+    {
+        $o = new OAuth2($this->minimal);
+        $o->setGrantType('http://a/grant/url');
+        $this->assertEquals('http://a/grant/url', $o->getGrantType());
+    }
 }
 
 class OAuth2GetCacheKeyTest extends \PHPUnit_Framework_TestCase
 {
-  private $minimal = [
-      'clientID' => 'aClientID'
-  ];
+    private $minimal = [
+        'clientID' => 'aClientID',
+    ];
 
-  public function testIsNullWithNoScopes()
-  {
-    $o = new OAuth2($this->minimal);
-    $this->assertNull($o->getCacheKey());
-  }
+    public function testIsNullWithNoScopes()
+    {
+        $o = new OAuth2($this->minimal);
+        $this->assertNull($o->getCacheKey());
+    }
 
-  public function testIsScopeIfSingleScope()
-  {
-    $o = new OAuth2($this->minimal);
-    $o->setScope('test/scope/1');
-    $this->assertEquals('test/scope/1', $o->getCacheKey());
-  }
+    public function testIsScopeIfSingleScope()
+    {
+        $o = new OAuth2($this->minimal);
+        $o->setScope('test/scope/1');
+        $this->assertEquals('test/scope/1', $o->getCacheKey());
+    }
 
-  public function testIsAllScopesWhenScopeIsArray()
-  {
-    $o = new OAuth2($this->minimal);
-    $o->setScope(['test/scope/1', 'test/scope/2']);
-    $this->assertEquals('test/scope/1:test/scope/2', $o->getCacheKey());
-  }
+    public function testIsAllScopesWhenScopeIsArray()
+    {
+        $o = new OAuth2($this->minimal);
+        $o->setScope(['test/scope/1', 'test/scope/2']);
+        $this->assertEquals('test/scope/1:test/scope/2', $o->getCacheKey());
+    }
 }
 
 class OAuth2TimingTest extends \PHPUnit_Framework_TestCase
 {
-  private $minimal = [
-      'authorizationUri' => 'https://accounts.test.org/insecure/url',
-      'redirectUri' => 'https://accounts.test.org/redirect/url',
-      'clientId' => 'aClientID'
-  ];
+    private $minimal = [
+        'authorizationUri' => 'https://accounts.test.org/insecure/url',
+        'redirectUri' => 'https://accounts.test.org/redirect/url',
+        'clientId' => 'aClientID',
+    ];
 
-  public function testIssuedAtDefaultsToNull()
-  {
-    $o = new OAuth2($this->minimal);
-    $this->assertNull($o->getIssuedAt());
-  }
+    public function testIssuedAtDefaultsToNull()
+    {
+        $o = new OAuth2($this->minimal);
+        $this->assertNull($o->getIssuedAt());
+    }
 
-  public function testExpiresAtDefaultsToNull()
-  {
-    $o = new OAuth2($this->minimal);
-    $this->assertNull($o->getExpiresAt());
-  }
+    public function testExpiresAtDefaultsToNull()
+    {
+        $o = new OAuth2($this->minimal);
+        $this->assertNull($o->getExpiresAt());
+    }
 
-  public function testExpiresInDefaultsToNull()
-  {
-    $o = new OAuth2($this->minimal);
-    $this->assertNull($o->getExpiresIn());
-  }
+    public function testExpiresInDefaultsToNull()
+    {
+        $o = new OAuth2($this->minimal);
+        $this->assertNull($o->getExpiresIn());
+    }
 
-  public function testSettingExpiresInSetsIssuedAt()
-  {
-    $o = new OAuth2($this->minimal);
-    $this->assertNull($o->getIssuedAt());
-    $aShortWhile = 5;
-    $o->setExpiresIn($aShortWhile);
-    $this->assertEquals($aShortWhile, $o->getExpiresIn());
-    $this->assertNotNull($o->getIssuedAt());
-  }
+    public function testSettingExpiresInSetsIssuedAt()
+    {
+        $o = new OAuth2($this->minimal);
+        $this->assertNull($o->getIssuedAt());
+        $aShortWhile = 5;
+        $o->setExpiresIn($aShortWhile);
+        $this->assertEquals($aShortWhile, $o->getExpiresIn());
+        $this->assertNotNull($o->getIssuedAt());
+    }
 
-  public function testSettingExpiresInSetsExpireAt()
-  {
-    $o = new OAuth2($this->minimal);
-    $this->assertNull($o->getExpiresAt());
-    $aShortWhile = 5;
-    $o->setExpiresIn($aShortWhile);
-    $this->assertNotNull($o->getExpiresAt());
-    $this->assertEquals($aShortWhile, $o->getExpiresAt() - $o->getIssuedAt());
-  }
+    public function testSettingExpiresInSetsExpireAt()
+    {
+        $o = new OAuth2($this->minimal);
+        $this->assertNull($o->getExpiresAt());
+        $aShortWhile = 5;
+        $o->setExpiresIn($aShortWhile);
+        $this->assertNotNull($o->getExpiresAt());
+        $this->assertEquals($aShortWhile, $o->getExpiresAt() - $o->getIssuedAt());
+    }
 
-  public function testIsNotExpiredByDefault()
-  {
-    $o = new OAuth2($this->minimal);
-    $this->assertFalse($o->isExpired());
-  }
+    public function testIsNotExpiredByDefault()
+    {
+        $o = new OAuth2($this->minimal);
+        $this->assertFalse($o->isExpired());
+    }
 
-  public function testIsNotExpiredIfExpiresAtIsOld()
-  {
-    $o = new OAuth2($this->minimal);
-    $o->setExpiresAt(time() - 2);
-    $this->assertTrue($o->isExpired());
-  }
+    public function testIsNotExpiredIfExpiresAtIsOld()
+    {
+        $o = new OAuth2($this->minimal);
+        $o->setExpiresAt(time() - 2);
+        $this->assertTrue($o->isExpired());
+    }
 }
 
 class OAuth2GeneralTest extends \PHPUnit_Framework_TestCase
 {
-  private $minimal = [
-      'authorizationUri' => 'https://accounts.test.org/insecure/url',
-      'redirectUri' => 'https://accounts.test.org/redirect/url',
-      'clientId' => 'aClientID'
-  ];
+    private $minimal = [
+        'authorizationUri' => 'https://accounts.test.org/insecure/url',
+        'redirectUri' => 'https://accounts.test.org/redirect/url',
+        'clientId' => 'aClientID',
+    ];
 
-  /**
-   * @expectedException InvalidArgumentException
-   */
-  public function testFailsOnUnknownSigningAlgorithm()
-  {
-    $o = new OAuth2($this->minimal);
-    $o->setSigningAlgorithm('this is definitely not an algorithm name');
-  }
-
-  public function testAllowsKnownSigningAlgorithms()
-  {
-    $o = new OAuth2($this->minimal);
-    foreach (OAuth2::$knownSigningAlgorithms as $a) {
-      $o->setSigningAlgorithm($a);
-      $this->assertEquals($a, $o->getSigningAlgorithm());
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testFailsOnUnknownSigningAlgorithm()
+    {
+        $o = new OAuth2($this->minimal);
+        $o->setSigningAlgorithm('this is definitely not an algorithm name');
     }
-  }
 
-  /**
-   * @expectedException InvalidArgumentException
-   */
-  public function testFailsOnRelativeRedirectUri()
-  {
-    $o = new OAuth2($this->minimal);
-    $o->setRedirectUri('/relative/url');
-  }
+    public function testAllowsKnownSigningAlgorithms()
+    {
+        $o = new OAuth2($this->minimal);
+        foreach (OAuth2::$knownSigningAlgorithms as $a) {
+            $o->setSigningAlgorithm($a);
+            $this->assertEquals($a, $o->getSigningAlgorithm());
+        }
+    }
 
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testFailsOnRelativeRedirectUri()
+    {
+        $o = new OAuth2($this->minimal);
+        $o->setRedirectUri('/relative/url');
+    }
 
-  public function testAllowsUrnRedirectUri()
-  {
-    $urn = 'urn:ietf:wg:oauth:2.0:oob';
-    $o = new OAuth2($this->minimal);
-    $o->setRedirectUri($urn);
-    $this->assertEquals($urn, $o->getRedirectUri());
-  }
+    public function testAllowsUrnRedirectUri()
+    {
+        $urn = 'urn:ietf:wg:oauth:2.0:oob';
+        $o = new OAuth2($this->minimal);
+        $o->setRedirectUri($urn);
+        $this->assertEquals($urn, $o->getRedirectUri());
+    }
 }
 
 class OAuth2JwtTest extends \PHPUnit_Framework_TestCase
 {
-  private $signingMinimal = [
-      'signingKey' => 'example_key',
-      'signingAlgorithm' => 'HS256',
-      'scope' => 'https://www.googleapis.com/auth/userinfo.profile',
-      'issuer' => 'app@example.com',
-      'audience' => 'accounts.google.com',
-      'clientId' => 'aClientID'
-  ];
+    private $signingMinimal = [
+        'signingKey' => 'example_key',
+        'signingAlgorithm' => 'HS256',
+        'scope' => 'https://www.googleapis.com/auth/userinfo.profile',
+        'issuer' => 'app@example.com',
+        'audience' => 'accounts.google.com',
+        'clientId' => 'aClientID',
+    ];
 
-  /**
-   * @expectedException DomainException
-   */
-  public function testFailsWithMissingAudience()
-  {
-    $testConfig = $this->signingMinimal;
-    unset($testConfig['audience']);
-    $o = new OAuth2($testConfig);
-    $o->toJwt();
-  }
-
-  /**
-   * @expectedException DomainException
-   */
-  public function testFailsWithMissingIssuer()
-  {
-    $testConfig = $this->signingMinimal;
-    unset($testConfig['issuer']);
-    $o = new OAuth2($testConfig);
-    $o->toJwt();
-  }
-
-  /**
-   */
-  public function testCanHaveNoScope()
-  {
-    $testConfig = $this->signingMinimal;
-    unset($testConfig['scope']);
-    $o = new OAuth2($testConfig);
-    $o->toJwt();
-  }
-
-  /**
-   * @expectedException DomainException
-   */
-  public function testFailsWithMissingSigningKey()
-  {
-    $testConfig = $this->signingMinimal;
-    unset($testConfig['signingKey']);
-    $o = new OAuth2($testConfig);
-    $o->toJwt();
-  }
-
-  /**
-   * @expectedException DomainException
-   */
-  public function testFailsWithMissingSigningAlgorithm()
-  {
-    $testConfig = $this->signingMinimal;
-    unset($testConfig['signingAlgorithm']);
-    $o = new OAuth2($testConfig);
-    $o->toJwt();
-  }
-
-  public function testCanHS256EncodeAValidPayload()
-  {
-    $testConfig = $this->signingMinimal;
-    $o = new OAuth2($testConfig);
-    $payload = $o->toJwt();
-    $roundTrip = $this->jwtDecode($payload, $testConfig['signingKey'], array('HS256')) ;
-    $this->assertEquals($roundTrip->iss, $testConfig['issuer']);
-    $this->assertEquals($roundTrip->aud, $testConfig['audience']);
-    $this->assertEquals($roundTrip->scope, $testConfig['scope']);
-  }
-
-  public function testCanRS256EncodeAValidPayload()
-  {
-    $publicKey = file_get_contents(__DIR__ . '/fixtures' . '/public.pem');
-    $privateKey = file_get_contents(__DIR__ . '/fixtures' . '/private.pem');
-    $testConfig = $this->signingMinimal;
-    $o = new OAuth2($testConfig);
-    $o->setSigningAlgorithm('RS256');
-    $o->setSigningKey($privateKey);
-    $payload = $o->toJwt();
-    $roundTrip = $this->jwtDecode($payload, $publicKey, array('RS256')) ;
-    $this->assertEquals($roundTrip->iss, $testConfig['issuer']);
-    $this->assertEquals($roundTrip->aud, $testConfig['audience']);
-    $this->assertEquals($roundTrip->scope, $testConfig['scope']);
-  }
-
-  private function jwtDecode()
-  {
-    $args = func_get_args();
-    $class = 'JWT';
-    if (class_exists('Firebase\JWT\JWT')) {
-      $class = 'Firebase\JWT\JWT';
+    /**
+     * @expectedException DomainException
+     */
+    public function testFailsWithMissingAudience()
+    {
+        $testConfig = $this->signingMinimal;
+        unset($testConfig['audience']);
+        $o = new OAuth2($testConfig);
+        $o->toJwt();
     }
 
-    return call_user_func_array("$class::decode", $args);
-  }
+    /**
+     * @expectedException DomainException
+     */
+    public function testFailsWithMissingIssuer()
+    {
+        $testConfig = $this->signingMinimal;
+        unset($testConfig['issuer']);
+        $o = new OAuth2($testConfig);
+        $o->toJwt();
+    }
+
+    /**
+     */
+    public function testCanHaveNoScope()
+    {
+        $testConfig = $this->signingMinimal;
+        unset($testConfig['scope']);
+        $o = new OAuth2($testConfig);
+        $o->toJwt();
+    }
+
+    /**
+     * @expectedException DomainException
+     */
+    public function testFailsWithMissingSigningKey()
+    {
+        $testConfig = $this->signingMinimal;
+        unset($testConfig['signingKey']);
+        $o = new OAuth2($testConfig);
+        $o->toJwt();
+    }
+
+    /**
+     * @expectedException DomainException
+     */
+    public function testFailsWithMissingSigningAlgorithm()
+    {
+        $testConfig = $this->signingMinimal;
+        unset($testConfig['signingAlgorithm']);
+        $o = new OAuth2($testConfig);
+        $o->toJwt();
+    }
+
+    public function testCanHS256EncodeAValidPayload()
+    {
+        $testConfig = $this->signingMinimal;
+        $o = new OAuth2($testConfig);
+        $payload = $o->toJwt();
+        $roundTrip = $this->jwtDecode($payload, $testConfig['signingKey'], array('HS256'));
+        $this->assertEquals($roundTrip->iss, $testConfig['issuer']);
+        $this->assertEquals($roundTrip->aud, $testConfig['audience']);
+        $this->assertEquals($roundTrip->scope, $testConfig['scope']);
+    }
+
+    public function testCanRS256EncodeAValidPayload()
+    {
+        $publicKey = file_get_contents(__DIR__.'/fixtures'.'/public.pem');
+        $privateKey = file_get_contents(__DIR__.'/fixtures'.'/private.pem');
+        $testConfig = $this->signingMinimal;
+        $o = new OAuth2($testConfig);
+        $o->setSigningAlgorithm('RS256');
+        $o->setSigningKey($privateKey);
+        $payload = $o->toJwt();
+        $roundTrip = $this->jwtDecode($payload, $publicKey, array('RS256'));
+        $this->assertEquals($roundTrip->iss, $testConfig['issuer']);
+        $this->assertEquals($roundTrip->aud, $testConfig['audience']);
+        $this->assertEquals($roundTrip->scope, $testConfig['scope']);
+    }
+
+    private function jwtDecode()
+    {
+        $args = func_get_args();
+        $class = 'JWT';
+        if (class_exists('Firebase\JWT\JWT')) {
+            $class = 'Firebase\JWT\JWT';
+        }
+
+        return call_user_func_array("$class::decode", $args);
+    }
 }
 
 class OAuth2GenerateAccessTokenRequestTest extends \PHPUnit_Framework_TestCase
 {
-  private $tokenRequestMinimal = [
-      'tokenCredentialUri' => 'https://tokens_r_us/test',
-      'scope' => 'https://www.googleapis.com/auth/userinfo.profile',
-      'issuer' => 'app@example.com',
-      'audience' => 'accounts.google.com',
-      'clientId' => 'aClientID'
-  ];
+    private $tokenRequestMinimal = [
+        'tokenCredentialUri' => 'https://tokens_r_us/test',
+        'scope' => 'https://www.googleapis.com/auth/userinfo.profile',
+        'issuer' => 'app@example.com',
+        'audience' => 'accounts.google.com',
+        'clientId' => 'aClientID',
+    ];
 
-  /**
-   * @expectedException DomainException
-   */
-  public function testFailsIfNoTokenCredentialUri()
-  {
-    $testConfig = $this->tokenRequestMinimal;
-    unset($testConfig['tokenCredentialUri']);
-    $o = new OAuth2($testConfig);
-    $o->generateCredentialsRequest();
-  }
+    /**
+     * @expectedException DomainException
+     */
+    public function testFailsIfNoTokenCredentialUri()
+    {
+        $testConfig = $this->tokenRequestMinimal;
+        unset($testConfig['tokenCredentialUri']);
+        $o = new OAuth2($testConfig);
+        $o->generateCredentialsRequest();
+    }
 
-  /**
-   * @expectedException DomainException
-   */
-  public function testFailsIfAuthorizationCodeIsMissing()
-  {
-    $testConfig = $this->tokenRequestMinimal;
-    $testConfig['redirectUri'] = 'https://has/redirect/uri';
-    $o = new OAuth2($testConfig);
-    $o->generateCredentialsRequest();
-  }
+    /**
+     * @expectedException DomainException
+     */
+    public function testFailsIfAuthorizationCodeIsMissing()
+    {
+        $testConfig = $this->tokenRequestMinimal;
+        $testConfig['redirectUri'] = 'https://has/redirect/uri';
+        $o = new OAuth2($testConfig);
+        $o->generateCredentialsRequest();
+    }
 
-  public function testGeneratesAuthorizationCodeRequests()
-  {
-    $testConfig = $this->tokenRequestMinimal;
-    $testConfig['redirectUri'] = 'https://has/redirect/uri';
-    $o = new OAuth2($testConfig);
-    $o->setCode('an_auth_code');
+    public function testGeneratesAuthorizationCodeRequests()
+    {
+        $testConfig = $this->tokenRequestMinimal;
+        $testConfig['redirectUri'] = 'https://has/redirect/uri';
+        $o = new OAuth2($testConfig);
+        $o->setCode('an_auth_code');
 
-    // Generate the request and confirm that it's correct.
-    $req = $o->generateCredentialsRequest();
-    $this->assertInstanceOf('Psr\Http\Message\RequestInterface', $req);
-    $this->assertEquals('POST', $req->getMethod());
-    $fields = Psr7\parse_query((string) $req->getBody());
-    $this->assertEquals('authorization_code', $fields['grant_type']);
-    $this->assertEquals('an_auth_code', $fields['code']);
-  }
+        // Generate the request and confirm that it's correct.
+        $req = $o->generateCredentialsRequest();
+        $this->assertInstanceOf('Psr\Http\Message\RequestInterface', $req);
+        $this->assertEquals('POST', $req->getMethod());
+        $fields = Psr7\parse_query((string)$req->getBody());
+        $this->assertEquals('authorization_code', $fields['grant_type']);
+        $this->assertEquals('an_auth_code', $fields['code']);
+    }
 
-  public function testGeneratesPasswordRequests()
-  {
-    $testConfig = $this->tokenRequestMinimal;
-    $o = new OAuth2($testConfig);
-    $o->setUsername('a_username');
-    $o->setPassword('a_password');
+    public function testGeneratesPasswordRequests()
+    {
+        $testConfig = $this->tokenRequestMinimal;
+        $o = new OAuth2($testConfig);
+        $o->setUsername('a_username');
+        $o->setPassword('a_password');
 
-    // Generate the request and confirm that it's correct.
-    $req = $o->generateCredentialsRequest();
-    $this->assertInstanceOf('Psr\Http\Message\RequestInterface', $req);
-    $this->assertEquals('POST', $req->getMethod());
-    $fields = Psr7\parse_query((string) $req->getBody());
-    $this->assertEquals('password', $fields['grant_type']);
-    $this->assertEquals('a_password', $fields['password']);
-    $this->assertEquals('a_username', $fields['username']);
-  }
+        // Generate the request and confirm that it's correct.
+        $req = $o->generateCredentialsRequest();
+        $this->assertInstanceOf('Psr\Http\Message\RequestInterface', $req);
+        $this->assertEquals('POST', $req->getMethod());
+        $fields = Psr7\parse_query((string)$req->getBody());
+        $this->assertEquals('password', $fields['grant_type']);
+        $this->assertEquals('a_password', $fields['password']);
+        $this->assertEquals('a_username', $fields['username']);
+    }
 
-  public function testGeneratesRefreshTokenRequests()
-  {
-    $testConfig = $this->tokenRequestMinimal;
-    $o = new OAuth2($testConfig);
-    $o->setRefreshToken('a_refresh_token');
+    public function testGeneratesRefreshTokenRequests()
+    {
+        $testConfig = $this->tokenRequestMinimal;
+        $o = new OAuth2($testConfig);
+        $o->setRefreshToken('a_refresh_token');
 
-    // Generate the request and confirm that it's correct.
-    $req = $o->generateCredentialsRequest();
-    $this->assertInstanceOf('Psr\Http\Message\RequestInterface', $req);
-    $this->assertEquals('POST', $req->getMethod());
-    $fields = Psr7\parse_query((string) $req->getBody());
-    $this->assertEquals('refresh_token', $fields['grant_type']);
-    $this->assertEquals('a_refresh_token', $fields['refresh_token']);
-  }
+        // Generate the request and confirm that it's correct.
+        $req = $o->generateCredentialsRequest();
+        $this->assertInstanceOf('Psr\Http\Message\RequestInterface', $req);
+        $this->assertEquals('POST', $req->getMethod());
+        $fields = Psr7\parse_query((string)$req->getBody());
+        $this->assertEquals('refresh_token', $fields['grant_type']);
+        $this->assertEquals('a_refresh_token', $fields['refresh_token']);
+    }
 
-  public function testClientSecretAddedIfSetForAuthorizationCodeRequests()
-  {
-    $testConfig = $this->tokenRequestMinimal;
-    $testConfig['clientSecret'] = 'a_client_secret';
-    $testConfig['redirectUri'] = 'https://has/redirect/uri';
-    $o = new OAuth2($testConfig);
-    $o->setCode('an_auth_code');
-    $request = $o->generateCredentialsRequest();
-    $fields = Psr7\parse_query((string) $request->getBody());
-    $this->assertEquals('a_client_secret', $fields['client_secret']);
-  }
+    public function testClientSecretAddedIfSetForAuthorizationCodeRequests()
+    {
+        $testConfig = $this->tokenRequestMinimal;
+        $testConfig['clientSecret'] = 'a_client_secret';
+        $testConfig['redirectUri'] = 'https://has/redirect/uri';
+        $o = new OAuth2($testConfig);
+        $o->setCode('an_auth_code');
+        $request = $o->generateCredentialsRequest();
+        $fields = Psr7\parse_query((string)$request->getBody());
+        $this->assertEquals('a_client_secret', $fields['client_secret']);
+    }
 
-  public function testClientSecretAddedIfSetForRefreshTokenRequests()
-  {
-    $testConfig = $this->tokenRequestMinimal;
-    $testConfig['clientSecret'] = 'a_client_secret';
-    $o = new OAuth2($testConfig);
-    $o->setRefreshToken('a_refresh_token');
-    $request = $o->generateCredentialsRequest();
-    $fields = Psr7\parse_query((string) $request->getBody());
-    $this->assertEquals('a_client_secret', $fields['client_secret']);
-  }
+    public function testClientSecretAddedIfSetForRefreshTokenRequests()
+    {
+        $testConfig = $this->tokenRequestMinimal;
+        $testConfig['clientSecret'] = 'a_client_secret';
+        $o = new OAuth2($testConfig);
+        $o->setRefreshToken('a_refresh_token');
+        $request = $o->generateCredentialsRequest();
+        $fields = Psr7\parse_query((string)$request->getBody());
+        $this->assertEquals('a_client_secret', $fields['client_secret']);
+    }
 
-  public function testClientSecretAddedIfSetForPasswordRequests()
-  {
-    $testConfig = $this->tokenRequestMinimal;
-    $testConfig['clientSecret'] = 'a_client_secret';
-    $o = new OAuth2($testConfig);
-    $o->setUsername('a_username');
-    $o->setPassword('a_password');
-    $request = $o->generateCredentialsRequest();
-    $fields = Psr7\parse_query((string) $request->getBody());
-    $this->assertEquals('a_client_secret', $fields['client_secret']);
-  }
+    public function testClientSecretAddedIfSetForPasswordRequests()
+    {
+        $testConfig = $this->tokenRequestMinimal;
+        $testConfig['clientSecret'] = 'a_client_secret';
+        $o = new OAuth2($testConfig);
+        $o->setUsername('a_username');
+        $o->setPassword('a_password');
+        $request = $o->generateCredentialsRequest();
+        $fields = Psr7\parse_query((string)$request->getBody());
+        $this->assertEquals('a_client_secret', $fields['client_secret']);
+    }
 
-  public function testGeneratesAssertionRequests()
-  {
-    $testConfig = $this->tokenRequestMinimal;
-    $o = new OAuth2($testConfig);
-    $o->setSigningKey('a_key');
-    $o->setSigningAlgorithm('HS256');
+    public function testGeneratesAssertionRequests()
+    {
+        $testConfig = $this->tokenRequestMinimal;
+        $o = new OAuth2($testConfig);
+        $o->setSigningKey('a_key');
+        $o->setSigningAlgorithm('HS256');
 
-    // Generate the request and confirm that it's correct.
-    $req = $o->generateCredentialsRequest();
-    $this->assertInstanceOf('Psr\Http\Message\RequestInterface', $req);
-    $this->assertEquals('POST', $req->getMethod());
-    $fields = Psr7\parse_query((string) $req->getBody());
-    $this->assertEquals(OAuth2::JWT_URN, $fields['grant_type']);
-    $this->assertTrue(array_key_exists('assertion', $fields));
-  }
+        // Generate the request and confirm that it's correct.
+        $req = $o->generateCredentialsRequest();
+        $this->assertInstanceOf('Psr\Http\Message\RequestInterface', $req);
+        $this->assertEquals('POST', $req->getMethod());
+        $fields = Psr7\parse_query((string)$req->getBody());
+        $this->assertEquals(OAuth2::JWT_URN, $fields['grant_type']);
+        $this->assertTrue(array_key_exists('assertion', $fields));
+    }
 
-  public function testGeneratesExtendedRequests()
-  {
-    $testConfig = $this->tokenRequestMinimal;
-    $o = new OAuth2($testConfig);
-    $o->setGrantType('urn:my_test_grant_type');
-    $o->setExtensionParams(['my_param' => 'my_value']);
+    public function testGeneratesExtendedRequests()
+    {
+        $testConfig = $this->tokenRequestMinimal;
+        $o = new OAuth2($testConfig);
+        $o->setGrantType('urn:my_test_grant_type');
+        $o->setExtensionParams(['my_param' => 'my_value']);
 
-    // Generate the request and confirm that it's correct.
-    $req = $o->generateCredentialsRequest();
-    $this->assertInstanceOf('Psr\Http\Message\RequestInterface', $req);
-    $this->assertEquals('POST', $req->getMethod());
-    $fields = Psr7\parse_query((string) $req->getBody());
-    $this->assertEquals('my_value', $fields['my_param']);
-    $this->assertEquals('urn:my_test_grant_type', $fields['grant_type']);
-  }
+        // Generate the request and confirm that it's correct.
+        $req = $o->generateCredentialsRequest();
+        $this->assertInstanceOf('Psr\Http\Message\RequestInterface', $req);
+        $this->assertEquals('POST', $req->getMethod());
+        $fields = Psr7\parse_query((string)$req->getBody());
+        $this->assertEquals('my_value', $fields['my_param']);
+        $this->assertEquals('urn:my_test_grant_type', $fields['grant_type']);
+    }
 }
 
 class OAuth2FetchAuthTokenTest extends \PHPUnit_Framework_TestCase
 {
-  private $fetchAuthTokenMinimal = [
-      'tokenCredentialUri' => 'https://tokens_r_us/test',
-      'scope' => 'https://www.googleapis.com/auth/userinfo.profile',
-      'signingKey' => 'example_key',
-      'signingAlgorithm' => 'HS256',
-      'issuer' => 'app@example.com',
-      'audience' => 'accounts.google.com',
-      'clientId' => 'aClientID'
-  ];
-
-  /**
-   * @expectedException GuzzleHttp\Exception\ClientException
-   */
-  public function testFailsOn400()
-  {
-    $testConfig = $this->fetchAuthTokenMinimal;
-    $httpHandler = getHandler([
-      buildResponse(400)
-    ]);
-    $o = new OAuth2($testConfig);
-    $o->fetchAuthToken($httpHandler);
-  }
-
-  /**
-   * @expectedException GuzzleHttp\Exception\ServerException
-   */
-  public function testFailsOn500()
-  {
-    $testConfig = $this->fetchAuthTokenMinimal;
-    $httpHandler = getHandler([
-      buildResponse(500)
-    ]);
-    $o = new OAuth2($testConfig);
-    $o->fetchAuthToken($httpHandler);
-  }
-
-  /**
-   * @expectedException Exception
-   * @expectedExceptionMessage Invalid JSON response
-   */
-  public function testFailsOnNoContentTypeIfResponseIsNotJSON()
-  {
-    $testConfig = $this->fetchAuthTokenMinimal;
-    $notJson = '{"foo": , this is cannot be passed as json" "bar"}';
-    $httpHandler = getHandler([
-      buildResponse(200, [], Psr7\stream_for($notJson))
-    ]);
-    $o = new OAuth2($testConfig);
-    $o->fetchAuthToken($httpHandler);
-  }
-
-  public function testFetchesJsonResponseOnNoContentTypeOK()
-  {
-    $testConfig = $this->fetchAuthTokenMinimal;
-    $json = '{"foo": "bar"}';
-    $httpHandler = getHandler([
-      buildResponse(200, [], Psr7\stream_for($json))
-    ]);
-    $o = new OAuth2($testConfig);
-    $tokens = $o->fetchAuthToken($httpHandler);
-    $this->assertEquals($tokens['foo'], 'bar');
-  }
-
-  public function testFetchesFromFormEncodedResponseOK()
-  {
-    $testConfig = $this->fetchAuthTokenMinimal;
-    $json = 'foo=bar&spice=nice';
-    $httpHandler = getHandler([
-      buildResponse(
-        200,
-        ['Content-Type' => 'application/x-www-form-urlencoded'],
-        Psr7\stream_for($json)
-      )
-    ]);
-    $o = new OAuth2($testConfig);
-    $tokens = $o->fetchAuthToken($httpHandler);
-    $this->assertEquals($tokens['foo'], 'bar');
-    $this->assertEquals($tokens['spice'], 'nice');
-  }
-
-  public function testUpdatesTokenFieldsOnFetch()
-  {
-    $testConfig = $this->fetchAuthTokenMinimal;
-    $wanted_updates = [
-        'expires_at' => '1',
-        'expires_in' => '57',
-        'issued_at' => '2',
-        'access_token' => 'an_access_token',
-        'id_token' => 'an_id_token',
-        'refresh_token' => 'a_refresh_token',
+    private $fetchAuthTokenMinimal = [
+        'tokenCredentialUri' => 'https://tokens_r_us/test',
+        'scope' => 'https://www.googleapis.com/auth/userinfo.profile',
+        'signingKey' => 'example_key',
+        'signingAlgorithm' => 'HS256',
+        'issuer' => 'app@example.com',
+        'audience' => 'accounts.google.com',
+        'clientId' => 'aClientID',
     ];
-    $json = json_encode($wanted_updates);
-    $httpHandler = getHandler([
-      buildResponse(200, [], Psr7\stream_for($json))
-    ]);
-    $o = new OAuth2($testConfig);
-    $this->assertNull($o->getExpiresAt());
-    $this->assertNull($o->getExpiresIn());
-    $this->assertNull($o->getIssuedAt());
-    $this->assertNull($o->getAccessToken());
-    $this->assertNull($o->getIdToken());
-    $this->assertNull($o->getRefreshToken());
-    $tokens = $o->fetchAuthToken($httpHandler);
-    $this->assertEquals(1, $o->getExpiresAt());
-    $this->assertEquals(57, $o->getExpiresIn());
-    $this->assertEquals(2, $o->getIssuedAt());
-    $this->assertEquals('an_access_token', $o->getAccessToken());
-    $this->assertEquals('an_id_token', $o->getIdToken());
-    $this->assertEquals('a_refresh_token', $o->getRefreshToken());
-  }
+
+    /**
+     * @expectedException GuzzleHttp\Exception\ClientException
+     */
+    public function testFailsOn400()
+    {
+        $testConfig = $this->fetchAuthTokenMinimal;
+        $httpHandler = getHandler([
+            buildResponse(400),
+        ]);
+        $o = new OAuth2($testConfig);
+        $o->fetchAuthToken($httpHandler);
+    }
+
+    /**
+     * @expectedException GuzzleHttp\Exception\ServerException
+     */
+    public function testFailsOn500()
+    {
+        $testConfig = $this->fetchAuthTokenMinimal;
+        $httpHandler = getHandler([
+            buildResponse(500),
+        ]);
+        $o = new OAuth2($testConfig);
+        $o->fetchAuthToken($httpHandler);
+    }
+
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage Invalid JSON response
+     */
+    public function testFailsOnNoContentTypeIfResponseIsNotJSON()
+    {
+        $testConfig = $this->fetchAuthTokenMinimal;
+        $notJson = '{"foo": , this is cannot be passed as json" "bar"}';
+        $httpHandler = getHandler([
+            buildResponse(200, [], Psr7\stream_for($notJson)),
+        ]);
+        $o = new OAuth2($testConfig);
+        $o->fetchAuthToken($httpHandler);
+    }
+
+    public function testFetchesJsonResponseOnNoContentTypeOK()
+    {
+        $testConfig = $this->fetchAuthTokenMinimal;
+        $json = '{"foo": "bar"}';
+        $httpHandler = getHandler([
+            buildResponse(200, [], Psr7\stream_for($json)),
+        ]);
+        $o = new OAuth2($testConfig);
+        $tokens = $o->fetchAuthToken($httpHandler);
+        $this->assertEquals($tokens['foo'], 'bar');
+    }
+
+    public function testFetchesFromFormEncodedResponseOK()
+    {
+        $testConfig = $this->fetchAuthTokenMinimal;
+        $json = 'foo=bar&spice=nice';
+        $httpHandler = getHandler([
+            buildResponse(
+                200,
+                ['Content-Type' => 'application/x-www-form-urlencoded'],
+                Psr7\stream_for($json)
+            ),
+        ]);
+        $o = new OAuth2($testConfig);
+        $tokens = $o->fetchAuthToken($httpHandler);
+        $this->assertEquals($tokens['foo'], 'bar');
+        $this->assertEquals($tokens['spice'], 'nice');
+    }
+
+    public function testUpdatesTokenFieldsOnFetch()
+    {
+        $testConfig = $this->fetchAuthTokenMinimal;
+        $wanted_updates = [
+            'expires_at' => '1',
+            'expires_in' => '57',
+            'issued_at' => '2',
+            'access_token' => 'an_access_token',
+            'id_token' => 'an_id_token',
+            'refresh_token' => 'a_refresh_token',
+        ];
+        $json = json_encode($wanted_updates);
+        $httpHandler = getHandler([
+            buildResponse(200, [], Psr7\stream_for($json)),
+        ]);
+        $o = new OAuth2($testConfig);
+        $this->assertNull($o->getExpiresAt());
+        $this->assertNull($o->getExpiresIn());
+        $this->assertNull($o->getIssuedAt());
+        $this->assertNull($o->getAccessToken());
+        $this->assertNull($o->getIdToken());
+        $this->assertNull($o->getRefreshToken());
+        $tokens = $o->fetchAuthToken($httpHandler);
+        $this->assertEquals(1, $o->getExpiresAt());
+        $this->assertEquals(57, $o->getExpiresIn());
+        $this->assertEquals(2, $o->getIssuedAt());
+        $this->assertEquals('an_access_token', $o->getAccessToken());
+        $this->assertEquals('an_id_token', $o->getIdToken());
+        $this->assertEquals('a_refresh_token', $o->getRefreshToken());
+    }
 }
 
 class OAuth2VerifyIdTokenTest extends \PHPUnit_Framework_TestCase
 {
-  private $publicKey;
-  private $privateKey;
-  private $verifyIdTokenMinimal = [
-      'scope' => 'https://www.googleapis.com/auth/userinfo.profile',
-      'audience' => 'myaccount.on.host.issuer.com',
-      'issuer' => 'an.issuer.com',
-      'clientId' => 'myaccount.on.host.issuer.com'
-  ];
-
-  public function setUp()
-  {
-    $this->publicKey =
-        file_get_contents(__DIR__ . '/fixtures' . '/public.pem');
-    $this->privateKey =
-        file_get_contents(__DIR__ . '/fixtures' . '/private.pem');
-  }
-
-  /**
-   * @expectedException UnexpectedValueException
-   */
-  public function testFailsIfIdTokenIsInvalid()
-  {
-    $testConfig = $this->verifyIdTokenMinimal;
-    $not_a_jwt = 'not a jot';
-    $o = new OAuth2($testConfig);
-    $o->setIdToken($not_a_jwt);
-    $o->verifyIdToken($this->publicKey);
-  }
-
-  /**
-   * @expectedException DomainException
-   */
-  public function testFailsIfAudienceIsMissing()
-  {
-    $testConfig = $this->verifyIdTokenMinimal;
-    $now = time();
-    $origIdToken = [
-        'issuer' => $testConfig['issuer'],
-        'exp' => $now + 65, // arbitrary
-        'iat' => $now,
+    private $publicKey;
+    private $privateKey;
+    private $verifyIdTokenMinimal = [
+        'scope' => 'https://www.googleapis.com/auth/userinfo.profile',
+        'audience' => 'myaccount.on.host.issuer.com',
+        'issuer' => 'an.issuer.com',
+        'clientId' => 'myaccount.on.host.issuer.com',
     ];
-    $o = new OAuth2($testConfig);
-    $jwtIdToken = $this->jwtEncode($origIdToken, $this->privateKey, 'RS256');
-    $o->setIdToken($jwtIdToken);
-    $o->verifyIdToken($this->publicKey);
-  }
 
-  /**
-   * @expectedException DomainException
-   */
-  public function testFailsIfAudienceIsWrong()
-  {
-    $now = time();
-    $testConfig = $this->verifyIdTokenMinimal;
-    $origIdToken = [
-        'aud' => 'a different audience',
-        'iss' => $testConfig['issuer'],
-        'exp' => $now + 65, // arbitrary
-        'iat' => $now,
-    ];
-    $o = new OAuth2($testConfig);
-    $jwtIdToken = $this->jwtEncode($origIdToken, $this->privateKey, 'RS256');
-    $o->setIdToken($jwtIdToken);
-    $o->verifyIdToken($this->publicKey);
-  }
-
-  public function testShouldReturnAValidIdToken()
-  {
-    $testConfig = $this->verifyIdTokenMinimal;
-    $now = time();
-    $origIdToken = [
-        'aud' => $testConfig['audience'],
-        'iss' => $testConfig['issuer'],
-        'exp' => $now + 65, // arbitrary
-        'iat' => $now,
-    ];
-    $o = new OAuth2($testConfig);
-    $alg = 'RS256';
-    $jwtIdToken = $this->jwtEncode($origIdToken, $this->privateKey, $alg);
-    $o->setIdToken($jwtIdToken);
-    $roundTrip = $o->verifyIdToken($this->publicKey, array($alg));
-    $this->assertEquals($origIdToken['aud'], $roundTrip->aud);
-  }
-
-  private function jwtEncode()
-  {
-    $args = func_get_args();
-    $class = 'JWT';
-    if (class_exists('Firebase\JWT\JWT')) {
-      $class = 'Firebase\JWT\JWT';
+    public function setUp()
+    {
+        $this->publicKey =
+            file_get_contents(__DIR__.'/fixtures'.'/public.pem');
+        $this->privateKey =
+            file_get_contents(__DIR__.'/fixtures'.'/private.pem');
     }
 
-    return call_user_func_array("$class::encode", $args);
-  }
+    /**
+     * @expectedException UnexpectedValueException
+     */
+    public function testFailsIfIdTokenIsInvalid()
+    {
+        $testConfig = $this->verifyIdTokenMinimal;
+        $not_a_jwt = 'not a jot';
+        $o = new OAuth2($testConfig);
+        $o->setIdToken($not_a_jwt);
+        $o->verifyIdToken($this->publicKey);
+    }
+
+    /**
+     * @expectedException DomainException
+     */
+    public function testFailsIfAudienceIsMissing()
+    {
+        $testConfig = $this->verifyIdTokenMinimal;
+        $now = time();
+        $origIdToken = [
+            'issuer' => $testConfig['issuer'],
+            'exp' => $now + 65, // arbitrary
+            'iat' => $now,
+        ];
+        $o = new OAuth2($testConfig);
+        $jwtIdToken = $this->jwtEncode($origIdToken, $this->privateKey, 'RS256');
+        $o->setIdToken($jwtIdToken);
+        $o->verifyIdToken($this->publicKey);
+    }
+
+    /**
+     * @expectedException DomainException
+     */
+    public function testFailsIfAudienceIsWrong()
+    {
+        $now = time();
+        $testConfig = $this->verifyIdTokenMinimal;
+        $origIdToken = [
+            'aud' => 'a different audience',
+            'iss' => $testConfig['issuer'],
+            'exp' => $now + 65, // arbitrary
+            'iat' => $now,
+        ];
+        $o = new OAuth2($testConfig);
+        $jwtIdToken = $this->jwtEncode($origIdToken, $this->privateKey, 'RS256');
+        $o->setIdToken($jwtIdToken);
+        $o->verifyIdToken($this->publicKey);
+    }
+
+    public function testShouldReturnAValidIdToken()
+    {
+        $testConfig = $this->verifyIdTokenMinimal;
+        $now = time();
+        $origIdToken = [
+            'aud' => $testConfig['audience'],
+            'iss' => $testConfig['issuer'],
+            'exp' => $now + 65, // arbitrary
+            'iat' => $now,
+        ];
+        $o = new OAuth2($testConfig);
+        $alg = 'RS256';
+        $jwtIdToken = $this->jwtEncode($origIdToken, $this->privateKey, $alg);
+        $o->setIdToken($jwtIdToken);
+        $roundTrip = $o->verifyIdToken($this->publicKey, array($alg));
+        $this->assertEquals($origIdToken['aud'], $roundTrip->aud);
+    }
+
+    private function jwtEncode()
+    {
+        $args = func_get_args();
+        $class = 'JWT';
+        if (class_exists('Firebase\JWT\JWT')) {
+            $class = 'Firebase\JWT\JWT';
+        }
+
+        return call_user_func_array("$class::encode", $args);
+    }
 }

--- a/tests/Subscriber/AuthTokenSubscriberTest.php
+++ b/tests/Subscriber/AuthTokenSubscriberTest.php
@@ -19,183 +19,183 @@ namespace Google\Auth\Tests;
 
 use Google\Auth\Subscriber\AuthTokenSubscriber;
 use GuzzleHttp\Client;
-use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Event\BeforeEvent;
 use GuzzleHttp\Transaction;
 
 class AuthTokenSubscriberTest extends BaseTest
 {
-  private $mockFetcher;
-  private $mockCache;
+    private $mockFetcher;
+    private $mockCache;
 
-  protected function setUp()
-  {
-    $this->onlyGuzzle5();
+    protected function setUp()
+    {
+        $this->onlyGuzzle5();
 
-    $this->mockFetcher =
-        $this
-        ->getMockBuilder('Google\Auth\FetchAuthTokenInterface')
-        ->getMock();
-    $this->mockCache =
-        $this
-        ->getMockBuilder('Google\Auth\CacheInterface')
-        ->getMock();
-  }
+        $this->mockFetcher =
+            $this
+                ->getMockBuilder('Google\Auth\FetchAuthTokenInterface')
+                ->getMock();
+        $this->mockCache =
+            $this
+                ->getMockBuilder('Google\Auth\CacheInterface')
+                ->getMock();
+    }
 
-  public function testSubscribesToEvents()
-  {
-    $a = new AuthTokenSubscriber($this->mockFetcher, array());
-    $this->assertArrayHasKey('before', $a->getEvents());
-  }
+    public function testSubscribesToEvents()
+    {
+        $a = new AuthTokenSubscriber($this->mockFetcher, array());
+        $this->assertArrayHasKey('before', $a->getEvents());
+    }
 
+    public function testOnlyTouchesWhenAuthConfigScoped()
+    {
+        $s = new AuthTokenSubscriber($this->mockFetcher, array());
+        $client = new Client();
+        $request = $client->createRequest('GET', 'http://testing.org',
+            ['auth' => 'not_google_auth']);
+        $before = new BeforeEvent(new Transaction($client, $request));
+        $s->onBefore($before);
+        $this->assertSame($request->getHeader('Authorization'), '');
+    }
 
-  public function testOnlyTouchesWhenAuthConfigScoped()
-  {
-    $s = new AuthTokenSubscriber($this->mockFetcher, array());
-    $client = new Client();
-    $request = $client->createRequest('GET', 'http://testing.org',
-                                      ['auth' => 'not_google_auth']);
-    $before = new BeforeEvent(new Transaction($client, $request));
-    $s->onBefore($before);
-    $this->assertSame($request->getHeader('Authorization'), '');
-  }
+    public function testAddsTheTokenAsAnAuthorizationHeader()
+    {
+        $authResult = ['access_token' => '1/abcdef1234567890'];
+        $this->mockFetcher
+            ->expects($this->once())
+            ->method('fetchAuthToken')
+            ->will($this->returnValue($authResult));
 
-  public function testAddsTheTokenAsAnAuthorizationHeader()
-  {
-    $authResult = ['access_token' => '1/abcdef1234567890'];
-    $this->mockFetcher
-        ->expects($this->once())
-        ->method('fetchAuthToken')
-        ->will($this->returnValue($authResult));
+        // Run the test.
+        $a = new AuthTokenSubscriber($this->mockFetcher, array());
+        $client = new Client();
+        $request = $client->createRequest('GET', 'http://testing.org',
+            ['auth' => 'google_auth']);
+        $before = new BeforeEvent(new Transaction($client, $request));
+        $a->onBefore($before);
+        $this->assertSame($request->getHeader('Authorization'),
+            'Bearer 1/abcdef1234567890');
+    }
 
-    // Run the test.
-    $a = new AuthTokenSubscriber($this->mockFetcher, array());
-    $client = new Client();
-    $request = $client->createRequest('GET', 'http://testing.org',
-                                      ['auth' => 'google_auth']);
-    $before = new BeforeEvent(new Transaction($client, $request));
-    $a->onBefore($before);
-    $this->assertSame($request->getHeader('Authorization'),
-                      'Bearer 1/abcdef1234567890');
-  }
+    public function testDoesNotAddAnAuthorizationHeaderOnNoAccessToken()
+    {
+        $authResult = ['not_access_token' => '1/abcdef1234567890'];
+        $this->mockFetcher
+            ->expects($this->once())
+            ->method('fetchAuthToken')
+            ->will($this->returnValue($authResult));
 
-  public function testDoesNotAddAnAuthorizationHeaderOnNoAccessToken()
-  {
-    $authResult = ['not_access_token' => '1/abcdef1234567890'];
-    $this->mockFetcher
-        ->expects($this->once())
-        ->method('fetchAuthToken')
-        ->will($this->returnValue($authResult));
+        // Run the test.
+        $a = new AuthTokenSubscriber($this->mockFetcher, array());
+        $client = new Client();
+        $request = $client->createRequest('GET', 'http://testing.org',
+            ['auth' => 'google_auth']);
+        $before = new BeforeEvent(new Transaction($client, $request));
+        $a->onBefore($before);
+        $this->assertSame($request->getHeader('Authorization'), '');
+    }
 
-    // Run the test.
-    $a = new AuthTokenSubscriber($this->mockFetcher, array());
-    $client = new Client();
-    $request = $client->createRequest('GET', 'http://testing.org',
-                                      ['auth' => 'google_auth']);
-    $before = new BeforeEvent(new Transaction($client, $request));
-    $a->onBefore($before);
-    $this->assertSame($request->getHeader('Authorization'), '');
-  }
+    public function testUsesCachedAuthToken()
+    {
+        $cacheKey = 'myKey';
+        $cachedValue = '2/abcdef1234567890';
+        $this->mockCache
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo($cacheKey),
+                $this->equalTo(AuthTokenSubscriber::DEFAULT_CACHE_LIFETIME))
+            ->will($this->returnValue($cachedValue));
+        $this->mockFetcher
+            ->expects($this->never())
+            ->method('fetchAuthToken');
+        $this->mockFetcher
+            ->expects($this->any())
+            ->method('getCacheKey')
+            ->will($this->returnValue($cacheKey));
 
-  public function testUsesCachedAuthToken()
-  {
-    $cacheKey = 'myKey';
-    $cachedValue = '2/abcdef1234567890';
-    $this->mockCache
-        ->expects($this->once())
-        ->method('get')
-        ->with($this->equalTo($cacheKey),
-               $this->equalTo(AuthTokenSubscriber::DEFAULT_CACHE_LIFETIME))
-        ->will($this->returnValue($cachedValue));
-    $this->mockFetcher
-        ->expects($this->never())
-        ->method('fetchAuthToken');
-    $this->mockFetcher
-        ->expects($this->any())
-        ->method('getCacheKey')
-        ->will($this->returnValue($cacheKey));
+        // Run the test.
+        $a = new AuthTokenSubscriber($this->mockFetcher, array(), $this->mockCache);
+        $client = new Client();
+        $request = $client->createRequest('GET', 'http://testing.org',
+            ['auth' => 'google_auth']);
+        $before = new BeforeEvent(new Transaction($client, $request));
+        $a->onBefore($before);
+        $this->assertSame($request->getHeader('Authorization'),
+            'Bearer 2/abcdef1234567890');
+    }
 
-    // Run the test.
-    $a = new AuthTokenSubscriber($this->mockFetcher, array(), $this->mockCache);
-    $client = new Client();
-    $request = $client->createRequest('GET', 'http://testing.org',
-                                      ['auth' => 'google_auth']);
-    $before = new BeforeEvent(new Transaction($client, $request));
-    $a->onBefore($before);
-    $this->assertSame($request->getHeader('Authorization'),
-                      'Bearer 2/abcdef1234567890');
-  }
+    public function testGetsCachedAuthTokenUsingCacheOptions()
+    {
+        $prefix = 'test_prefix:';
+        $lifetime = '70707';
+        $cacheKey = 'myKey';
+        $cachedValue = '2/abcdef1234567890';
+        $this->mockCache
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo($prefix.$cacheKey),
+                $this->equalTo($lifetime))
+            ->will($this->returnValue($cachedValue));
+        $this->mockFetcher
+            ->expects($this->never())
+            ->method('fetchAuthToken');
+        $this->mockFetcher
+            ->expects($this->any())
+            ->method('getCacheKey')
+            ->will($this->returnValue($cacheKey));
 
-  public function testGetsCachedAuthTokenUsingCacheOptions()
-  {
-    $prefix = 'test_prefix:';
-    $lifetime = '70707';
-    $cacheKey = 'myKey';
-    $cachedValue = '2/abcdef1234567890';
-    $this->mockCache
-        ->expects($this->once())
-        ->method('get')
-        ->with($this->equalTo($prefix . $cacheKey),
-               $this->equalTo($lifetime))
-        ->will($this->returnValue($cachedValue));
-    $this->mockFetcher
-        ->expects($this->never())
-        ->method('fetchAuthToken');
-    $this->mockFetcher
-        ->expects($this->any())
-        ->method('getCacheKey')
-        ->will($this->returnValue($cacheKey));
+        // Run the test
+        $a = new AuthTokenSubscriber($this->mockFetcher,
+            array(
+                'prefix' => $prefix,
+                'lifetime' => $lifetime,
+            ),
+            $this->mockCache);
+        $client = new Client();
+        $request = $client->createRequest('GET', 'http://testing.org',
+            ['auth' => 'google_auth']);
+        $before = new BeforeEvent(new Transaction($client, $request));
+        $a->onBefore($before);
+        $this->assertSame($request->getHeader('Authorization'),
+            'Bearer 2/abcdef1234567890');
+    }
 
-    // Run the test
-    $a = new AuthTokenSubscriber($this->mockFetcher,
-                              array('prefix' => $prefix,
-                                    'lifetime' => $lifetime),
-                              $this->mockCache);
-    $client = new Client();
-    $request = $client->createRequest('GET', 'http://testing.org',
-                                      ['auth' => 'google_auth']);
-    $before = new BeforeEvent(new Transaction($client, $request));
-    $a->onBefore($before);
-    $this->assertSame($request->getHeader('Authorization'),
-                      'Bearer 2/abcdef1234567890');
-  }
+    public function testShouldSaveValueInCacheWithSpecifiedPrefix()
+    {
+        $token = '1/abcdef1234567890';
+        $authResult = ['access_token' => $token];
+        $cacheKey = 'myKey';
+        $prefix = 'test_prefix:';
+        $this->mockCache
+            ->expects($this->any())
+            ->method('get')
+            ->will($this->returnValue(null));
+        $this->mockCache
+            ->expects($this->once())
+            ->method('set')
+            ->with($this->equalTo($prefix.$cacheKey),
+                $this->equalTo($token))
+            ->will($this->returnValue(false));
+        $this->mockFetcher
+            ->expects($this->any())
+            ->method('getCacheKey')
+            ->will($this->returnValue($cacheKey));
+        $this->mockFetcher
+            ->expects($this->once())
+            ->method('fetchAuthToken')
+            ->will($this->returnValue($authResult));
 
-  public function testShouldSaveValueInCacheWithSpecifiedPrefix()
-  {
-    $token = '1/abcdef1234567890';
-    $authResult = ['access_token' => $token];
-    $cacheKey = 'myKey';
-    $prefix = 'test_prefix:';
-    $this->mockCache
-        ->expects($this->any())
-        ->method('get')
-        ->will($this->returnValue(null));
-    $this->mockCache
-        ->expects($this->once())
-        ->method('set')
-        ->with($this->equalTo($prefix . $cacheKey),
-               $this->equalTo($token))
-        ->will($this->returnValue(false));
-    $this->mockFetcher
-        ->expects($this->any())
-        ->method('getCacheKey')
-        ->will($this->returnValue($cacheKey));
-    $this->mockFetcher
-        ->expects($this->once())
-        ->method('fetchAuthToken')
-        ->will($this->returnValue($authResult));
+        // Run the test
+        $a = new AuthTokenSubscriber($this->mockFetcher,
+            array('prefix' => $prefix),
+            $this->mockCache);
 
-    // Run the test
-    $a = new AuthTokenSubscriber($this->mockFetcher,
-                              array('prefix' => $prefix),
-                              $this->mockCache);
-
-    $client = new Client();
-    $request = $client->createRequest('GET', 'http://testing.org',
-                                      ['auth' => 'google_auth']);
-    $before = new BeforeEvent(new Transaction($client, $request));
-    $a->onBefore($before);
-    $this->assertSame($request->getHeader('Authorization'),
-                      'Bearer 1/abcdef1234567890');
-  }
+        $client = new Client();
+        $request = $client->createRequest('GET', 'http://testing.org',
+            ['auth' => 'google_auth']);
+        $before = new BeforeEvent(new Transaction($client, $request));
+        $a->onBefore($before);
+        $this->assertSame($request->getHeader('Authorization'),
+            'Bearer 1/abcdef1234567890');
+    }
 }

--- a/tests/Subscriber/SimpleSubscriberTest.php
+++ b/tests/Subscriber/SimpleSubscriberTest.php
@@ -24,47 +24,46 @@ use GuzzleHttp\Transaction;
 
 class SimpleSubscriberTest extends BaseTest
 {
-  protected function setUp()
-  {
-    $this->onlyGuzzle5();
-  }
+    protected function setUp()
+    {
+        $this->onlyGuzzle5();
+    }
 
-  /**
-   * @expectedException InvalidArgumentException
-   */
-  public function testRequiresADeveloperKey()
-  {
-    new SimpleSubscriber(['not_key' => 'a test key']);
-  }
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testRequiresADeveloperKey()
+    {
+        new SimpleSubscriber(['not_key' => 'a test key']);
+    }
 
-  public function testSubscribesToEvents()
-  {
-    $events = (new SimpleSubscriber(['key' => 'a test key']))->getEvents();
-    $this->assertArrayHasKey('before', $events);
-  }
+    public function testSubscribesToEvents()
+    {
+        $events = (new SimpleSubscriber(['key' => 'a test key']))->getEvents();
+        $this->assertArrayHasKey('before', $events);
+    }
 
-  public function testAddsTheKeyToTheQuery()
-  {
-    $s = new SimpleSubscriber(['key' => 'test_key']);
-    $client = new Client();
-    $request = $client->createRequest('GET', 'http://testing.org',
-                                      ['auth' => 'simple']);
-    $before = new BeforeEvent(new Transaction($client, $request));
-    $s->onBefore($before);
-    $this->assertCount(1, $request->getQuery());
-    $this->assertTrue($request->getQuery()->hasKey('key'));
-    $this->assertSame($request->getQuery()->get('key'), 'test_key');
-  }
+    public function testAddsTheKeyToTheQuery()
+    {
+        $s = new SimpleSubscriber(['key' => 'test_key']);
+        $client = new Client();
+        $request = $client->createRequest('GET', 'http://testing.org',
+            ['auth' => 'simple']);
+        $before = new BeforeEvent(new Transaction($client, $request));
+        $s->onBefore($before);
+        $this->assertCount(1, $request->getQuery());
+        $this->assertTrue($request->getQuery()->hasKey('key'));
+        $this->assertSame($request->getQuery()->get('key'), 'test_key');
+    }
 
-  public function testOnlyTouchesWhenAuthConfigIsSimple()
-  {
-    $s = new SimpleSubscriber(['key' => 'test_key']);
-    $client = new Client();
-    $request = $client->createRequest('GET', 'http://testing.org',
-                                      ['auth' => 'notsimple']);
-    $before = new BeforeEvent(new Transaction($client, $request));
-    $s->onBefore($before);
-    $this->assertCount(0, $request->getQuery());
-  }
-
+    public function testOnlyTouchesWhenAuthConfigIsSimple()
+    {
+        $s = new SimpleSubscriber(['key' => 'test_key']);
+        $client = new Client();
+        $request = $client->createRequest('GET', 'http://testing.org',
+            ['auth' => 'notsimple']);
+        $before = new BeforeEvent(new Transaction($client, $request));
+        $s->onBefore($before);
+        $this->assertCount(0, $request->getQuery());
+    }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -16,38 +16,40 @@
  */
 
 error_reporting(E_ALL | E_STRICT);
-require dirname(__DIR__) . '/vendor/autoload.php';
+require dirname(__DIR__).'/vendor/autoload.php';
 date_default_timezone_set('UTC');
 
 // autoload base test
-require_once __DIR__ . '/BaseTest.php';
+require_once __DIR__.'/BaseTest.php';
 
 function buildResponse($code, array $headers = [], $body = null)
 {
-  if (class_exists('GuzzleHttp\HandlerStack')) {
-    return new \GuzzleHttp\Psr7\Response($code, $headers, $body);
-  }
+    if (class_exists('GuzzleHttp\HandlerStack')) {
+        return new \GuzzleHttp\Psr7\Response($code, $headers, $body);
+    }
 
-  return new \GuzzleHttp\Message\Response(
-    $code,
-    $headers,
-    \GuzzleHttp\Stream\Stream::factory((string) $body)
-  );
+    return new \GuzzleHttp\Message\Response(
+        $code,
+        $headers,
+        \GuzzleHttp\Stream\Stream::factory((string)$body)
+    );
 }
 
 function getHandler(array $mockResponses = [])
 {
-  if (class_exists('GuzzleHttp\HandlerStack')) {
-    $mock = new \GuzzleHttp\Handler\MockHandler($mockResponses);
+    if (class_exists('GuzzleHttp\HandlerStack')) {
+        $mock = new \GuzzleHttp\Handler\MockHandler($mockResponses);
 
-    $handler = \GuzzleHttp\HandlerStack::create($mock);
-    $client = new \GuzzleHttp\Client(['handler' => $handler]);
-    return new \Google\Auth\HttpHandler\Guzzle6HttpHandler($client);
-  }
+        $handler = \GuzzleHttp\HandlerStack::create($mock);
+        $client = new \GuzzleHttp\Client(['handler' => $handler]);
 
-  $client = new \GuzzleHttp\Client();
-  $client->getEmitter()->attach(
-    new \GuzzleHttp\Subscriber\Mock($mockResponses)
-  );
-  return new \Google\Auth\HttpHandler\Guzzle5HttpHandler($client);
+        return new \Google\Auth\HttpHandler\Guzzle6HttpHandler($client);
+    }
+
+    $client = new \GuzzleHttp\Client();
+    $client->getEmitter()->attach(
+        new \GuzzleHttp\Subscriber\Mock($mockResponses)
+    );
+
+    return new \Google\Auth\HttpHandler\Guzzle5HttpHandler($client);
 }

--- a/tests/mocks/AppIdentityService.php
+++ b/tests/mocks/AppIdentityService.php
@@ -4,16 +4,16 @@ namespace google\appengine\api\app_identity;
 
 class AppIdentityService
 {
-  public static $scope;
-  public static $accessToken = array(
-    'access_token' => 'xyz',
-    'expiration_time' => '2147483646',
-  );
+    public static $scope;
+    public static $accessToken = array(
+        'access_token' => 'xyz',
+        'expiration_time' => '2147483646',
+    );
 
-  public static function getAccessToken($scope)
-  {
-    self::$scope = $scope;
+    public static function getAccessToken($scope)
+    {
+        self::$scope = $scope;
 
-    return self::$accessToken;
-  }
+        return self::$accessToken;
+    }
 }


### PR DESCRIPTION
Converting to PSR-2 is a reasonable choice since it's the de-facto coding standard in the PHP community.

The minor tweaks to the standard in the `.php_cs` config file are heavily inspired by the symfony and TYPO3 CMS coding standards. Adding the `.php_cs` config file allows for reproducable code-style conversion.

While on the task I added / corrected docblocks wherever possible.

Closes: #40