### PR TITLE
adds token callback to AuthToken Middleware & Subscriber

### DIFF
--- a/src/Middleware/AuthTokenMiddleware.php
+++ b/src/Middleware/AuthTokenMiddleware.php
@@ -161,7 +161,7 @@ class AuthTokenMiddleware
             // notify the callback if applicable
             if ($this->tokenCallback) {
                 $cacheKey = $this->cacheConfig['prefix'] . $this->fetcher->getCacheKey();
-                $this->tokenCallback->__invoke($cacheKey, $auth_tokens['access_token']);
+                call_user_func($this->tokenCallback, $cacheKey, $auth_tokens['access_token']);
             }
 
             return $auth_tokens['access_token'];

--- a/src/Middleware/AuthTokenMiddleware.php
+++ b/src/Middleware/AuthTokenMiddleware.php
@@ -60,21 +60,29 @@ class AuthTokenMiddleware
     private $cacheConfig;
 
     /**
+     * @var callable
+     */
+    private $tokenCallback;
+
+    /**
      * Creates a new AuthTokenMiddleware.
      *
      * @param FetchAuthTokenInterface $fetcher is used to fetch the auth token
      * @param array $cacheConfig configures the cache
      * @param CacheItemPoolInterface $cache (optional) caches the token.
      * @param callable $httpHandler (optional) callback which delivers psr7 request
+     * @param callable $tokenCallback (optional) function to be called when a new token is fetched.
      */
     public function __construct(
         FetchAuthTokenInterface $fetcher,
         array $cacheConfig = null,
         CacheItemPoolInterface $cache = null,
-        callable $httpHandler = null
+        callable $httpHandler = null,
+        callable $tokenCallback = null
     ) {
         $this->fetcher = $fetcher;
         $this->httpHandler = $httpHandler;
+        $this->tokenCallback = $tokenCallback;
         if (!is_null($cache)) {
             $this->cache = $cache;
             $this->cacheConfig = array_merge([
@@ -149,6 +157,12 @@ class AuthTokenMiddleware
 
         if (array_key_exists('access_token', $auth_tokens)) {
             $this->setCachedValue($auth_tokens['access_token']);
+
+            // notify the callback if applicable
+            if ($this->tokenCallback) {
+                $cacheKey = $this->cacheConfig['prefix'] . $this->fetcher->getCacheKey();
+                $this->tokenCallback->__invoke($cacheKey, $auth_tokens['access_token']);
+            }
 
             return $auth_tokens['access_token'];
         }

--- a/src/Subscriber/AuthTokenSubscriber.php
+++ b/src/Subscriber/AuthTokenSubscriber.php
@@ -157,7 +157,7 @@ class AuthTokenSubscriber implements SubscriberInterface
             // notify the callback if applicable
             if ($this->tokenCallback) {
                 $cacheKey = $this->cacheConfig['prefix'] . $this->fetcher->getCacheKey();
-                $this->tokenCallback->__invoke($cacheKey, $auth_tokens['access_token']);
+                call_user_func($this->tokenCallback, $cacheKey, $auth_tokens['access_token']);
             }
         }
     }

--- a/src/Subscriber/AuthTokenSubscriber.php
+++ b/src/Subscriber/AuthTokenSubscriber.php
@@ -62,21 +62,29 @@ class AuthTokenSubscriber implements SubscriberInterface
     private $cacheConfig;
 
     /**
+     * @var callable
+     */
+    private $tokenCallback;
+
+    /**
      * Creates a new AuthTokenSubscriber.
      *
      * @param FetchAuthTokenInterface $fetcher is used to fetch the auth token
      * @param array $cacheConfig configures the cache
      * @param CacheItemPoolInterface $cache (optional) caches the token.
      * @param callable $httpHandler (optional) http client to fetch the token.
+     * @param callable $tokenCallback (optional) function to be called when a new token is fetched.
      */
     public function __construct(
         FetchAuthTokenInterface $fetcher,
         array $cacheConfig = null,
         CacheItemPoolInterface $cache = null,
-        callable $httpHandler = null
+        callable $httpHandler = null,
+        callable $tokenCallback = null
     ) {
         $this->fetcher = $fetcher;
         $this->httpHandler = $httpHandler;
+        $this->tokenCallback = $tokenCallback;
         if (!is_null($cache)) {
             $this->cache = $cache;
             $this->cacheConfig = array_merge([
@@ -145,6 +153,12 @@ class AuthTokenSubscriber implements SubscriberInterface
         if (array_key_exists('access_token', $auth_tokens)) {
             $request->setHeader('Authorization', 'Bearer ' . $auth_tokens['access_token']);
             $this->setCachedValue($auth_tokens['access_token']);
+
+            // notify the callback if applicable
+            if ($this->tokenCallback) {
+                $cacheKey = $this->cacheConfig['prefix'] . $this->fetcher->getCacheKey();
+                $this->tokenCallback->__invoke($cacheKey, $auth_tokens['access_token']);
+            }
         }
     }
 }


### PR DESCRIPTION
This is an attempt to resolve https://github.com/google/google-api-php-client/issues/901 and provide a more elegant way for https://github.com/google/google-api-php-client/pull/905 and https://github.com/google/google-api-php-client/pull/925