### PR TITLE
Expose keyfile

### DIFF
--- a/src/Credentials/ServiceAccountCredentials.php
+++ b/src/Credentials/ServiceAccountCredentials.php
@@ -103,6 +103,8 @@ class ServiceAccountCredentials extends CredentialsLoader
             'sub' => $sub,
             'tokenCredentialUri' => self::TOKEN_CREDENTIAL_URI,
         ]);
+
+        $this->jsonKey = $jsonKey;
     }
 
     /**

--- a/src/Credentials/UserRefreshCredentials.php
+++ b/src/Credentials/UserRefreshCredentials.php
@@ -80,6 +80,8 @@ class UserRefreshCredentials extends CredentialsLoader
             'scope' => $scope,
             'tokenCredentialUri' => self::TOKEN_CREDENTIAL_URI,
         ]);
+
+        $this->jsonKey = $jsonKey;
     }
 
     /**

--- a/src/CredentialsLoader.php
+++ b/src/CredentialsLoader.php
@@ -35,6 +35,11 @@ abstract class CredentialsLoader implements FetchAuthTokenInterface
     const AUTH_METADATA_KEY = 'Authorization';
 
     /**
+     * @var array|null
+     */
+    protected $jsonKey;
+
+    /**
      * @param string $cause
      * @return string
      */
@@ -170,5 +175,15 @@ abstract class CredentialsLoader implements FetchAuthTokenInterface
         $metadata_copy[self::AUTH_METADATA_KEY] = array('Bearer ' . $result['access_token']);
 
         return $metadata_copy;
+    }
+
+    /**
+     * Get the contents of the json keyfile, if it exists
+     *
+     * @return array|null
+     */
+    public function getJsonKey()
+    {
+        return $this->jsonKey;
     }
 }

--- a/tests/Credentials/GCECredentialsTest.php
+++ b/tests/Credentials/GCECredentialsTest.php
@@ -107,4 +107,10 @@ class GCECredentialsFetchAuthTokenTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($wantedTokens, $g->fetchAuthToken($httpHandler));
         $this->assertEquals(time() + 57, $g->getLastReceivedToken()['expires_at']);
     }
+
+    public function testKeyFileReturnsNull()
+    {
+        $gce = new GCECredentials();
+        $this->assertNull($gce->getJsonKey());
+    }
 }

--- a/tests/Credentials/ServiceAccountCredentialsTest.php
+++ b/tests/Credentials/ServiceAccountCredentialsTest.php
@@ -33,6 +33,7 @@ function createTestJson()
         'client_email' => 'test@example.com',
         'client_id' => 'client123',
         'type' => 'service_account',
+        'project_id' => 'project_id'
     ];
 }
 
@@ -128,6 +129,18 @@ class SACConstructorTest extends \PHPUnit_Framework_TestCase
             $scope,
             $testJson
         );
+    }
+
+    public function testShouldPopulateKeyFile()
+    {
+        $testJson = createTestJson();
+        $scope = ['scope/1', 'scope/2'];
+        $sa = new ServiceAccountCredentials(
+            $scope,
+            $testJson
+        );
+
+        $this->assertEquals($sa->getJsonKey(), $testJson);
     }
 
     /**


### PR DESCRIPTION
Hello!

This pull request is part of a solution for GoogleCloudPlatform/gcloud-php#32.

The goal of this change is to allow access to json key data even in cases when a key is not explicitly given to the credentials loader. So when a key is loaded from the `GOOGLE_APPLICATION_CREDENTIALS` environment variable, or from the well-known path, applications using this library will have access to that information. In the case of gcloud-php, we will use it to attempt to determine the project ID even when one is not explicitly provided.