### PR TITLE
explicitly set AppEngine Flexible to use GCE credentials

### DIFF
--- a/src/ApplicationDefaultCredentials.php
+++ b/src/ApplicationDefaultCredentials.php
@@ -139,7 +139,8 @@ class ApplicationDefaultCredentials
         if (!is_null($jsonKey)) {
             return CredentialsLoader::makeCredentials($scope, $jsonKey);
         }
-        if (AppIdentityCredentials::onAppEngine()) {
+        if (AppIdentityCredentials::onAppEngine() &&
+            !GCECredentials::onAppEngineFlexible()) {
             return new AppIdentityCredentials($scope);
         }
         if (GCECredentials::onGce($httpHandler)) {

--- a/src/Credentials/GCECredentials.php
+++ b/src/Credentials/GCECredentials.php
@@ -101,6 +101,17 @@ class GCECredentials extends CredentialsLoader
     }
 
     /**
+     * Determines if this an App Engine Flexible instance, by accessing the
+     * GAE_VM environment variable.
+     *
+     * @return true if this an App Engine Flexible Instance, false otherwise
+     */
+    public static function onAppEngineFlexible()
+    {
+        return isset($_SERVER['GAE_VM']) && 'true' === $_SERVER['GAE_VM'];
+    }
+
+    /**
      * Determines if this a GCE instance, by accessing the expected metadata
      * host.
      * If $httpHandler is not specified a the default HttpHandler is used.

--- a/tests/Credentials/GCECredentialsTest.php
+++ b/tests/Credentials/GCECredentialsTest.php
@@ -56,6 +56,20 @@ class GCECredentialsOnGCETest extends \PHPUnit_Framework_TestCase
     }
 }
 
+class GCECredentialsOnAppEngineFlexibleTest extends \PHPUnit_Framework_TestCase
+{
+    public function testIsFalseByDefault()
+    {
+        $this->assertFalse(GCECredentials::onAppEngineFlexible());
+    }
+
+    public function testIsTrueWhenGaeVmIsTrue()
+    {
+        $_SERVER['GAE_VM'] = 'true';
+        $this->assertTrue(GCECredentials::onAppEngineFlexible());
+    }
+}
+
 class GCECredentialsGetCacheKeyTest extends \PHPUnit_Framework_TestCase
 {
     public function testShouldNotBeEmpty()


### PR DESCRIPTION
If a custom runtime is used in App Engine Flexible, or PHP is executing outside of `php-nginx` (in this environment, `SERVER_SOFTWARE` is [set explicitly](https://github.com/GoogleCloudPlatform/php-docker/blob/2be08b74359c6d5bfd54c058e86ada19b4bfb94b/php-nginx/fastcgi_params#L30)), the auth library tries to use `AppIdentityCredentials`, which fails because the [appengine php sdk](https://github.com/GoogleCloudPlatform/appengine-php-sdk) doesn't exist.