### PR TITLE
moves caching to wrapper class 'FetchAuthTokenCache' and adds Memory cache

### DIFF
--- a/src/Cache/InvalidArgumentException.php
+++ b/src/Cache/InvalidArgumentException.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Auth\Cache;
+
+use Psr\Cache\InvalidArgumentException as PsrInvalidArgumentException;
+
+class InvalidArgumentException extends \InvalidArgumentException implements PsrInvalidArgumentException
+{
+}

--- a/src/Cache/Item.php
+++ b/src/Cache/Item.php
@@ -1,0 +1,185 @@
+<?php
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Auth\Cache;
+
+use Psr\Cache\CacheItemInterface;
+
+/**
+ * A cache item.
+ */
+final class Item implements CacheItemInterface
+{
+    /**
+     * @var string
+     */
+    private $key;
+
+    /**
+     * @var mixed
+     */
+    private $value;
+
+    /**
+     * @var \DateTime
+     */
+    private $expiration;
+
+    /**
+     * @var bool
+     */
+    private $isHit = false;
+
+    /**
+     * @param string $key
+     */
+    public function __construct($key)
+    {
+        $this->key = $key;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getKey()
+    {
+        return $this->key;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get()
+    {
+        return $this->isHit() ? $this->value : null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isHit()
+    {
+        if (!$this->isHit) {
+            return false;
+        }
+
+        if ($this->expiration === null) {
+            return true;
+        }
+
+        return new \DateTime() < $this->expiration;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function set($value)
+    {
+        $this->isHit = true;
+        $this->value = $value;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function expiresAt($expiration)
+    {
+        if ($this->isValidExpiration($expiration)) {
+            $this->expiration = $expiration;
+
+            return $this;
+        }
+
+        $implementationMessage = interface_exists('DateTimeInterface')
+            ? 'implement interface DateTimeInterface'
+            : 'be an instance of DateTime';
+
+        $error = sprintf(
+            'Argument 1 passed to %s::expiresAt() must %s, %s given',
+            get_class($this),
+            $implementationMessage,
+            gettype($expiration)
+        );
+
+        $this->handleError($error);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function expiresAfter($time)
+    {
+        if (is_int($time)) {
+            $this->expiration = new \DateTime("now + $time seconds");
+        } elseif ($time instanceof \DateInterval) {
+            $this->expiration = (new \DateTime())->add($time);
+        } elseif ($time === null) {
+            $this->expiration = $time;
+        } else {
+            $message = 'Argument 1 passed to %s::expiresAfter() must be an ' .
+                       'instance of DateInterval or of the type integer, %s given';
+            $error = sprintf($message, get_class($this), gettype($expiration));
+
+            $this->handleError($error);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Handles an error.
+     *
+     * @param string $error
+     * @throws \TypeError
+     */
+    private function handleError($error)
+    {
+        if (class_exists('TypeError')) {
+            throw new \TypeError($error);
+        }
+
+        trigger_error($error, E_USER_ERROR);
+    }
+
+    /**
+     * Determines if an expiration is valid based on the rules defined by PSR6.
+     *
+     * @param mixed $expiration
+     * @return bool
+     */
+    private function isValidExpiration($expiration)
+    {
+        if ($expiration === null) {
+            return true;
+        }
+
+        // We test for two types here due to the fact the DateTimeInterface
+        // was not introduced until PHP 5.5. Checking for the DateTime type as
+        // well allows us to support 5.4.
+        if ($expiration instanceof \DateTimeInterface) {
+            return true;
+        }
+
+        if ($expiration instanceof \DateTime) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Cache/MemoryCacheItemPool.php
+++ b/src/Cache/MemoryCacheItemPool.php
@@ -1,0 +1,155 @@
+<?php
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Auth\Cache;
+
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * Simple in-memory cache implementation.
+ */
+final class MemoryCacheItemPool implements CacheItemPoolInterface
+{
+    /**
+     * @var CacheItemInterface[]
+     */
+    private $items;
+
+    /**
+     * @var CacheItemInterface[]
+     */
+    private $deferredItems;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getItem($key)
+    {
+        return current($this->getItems([$key]));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getItems(array $keys = [])
+    {
+        $items = [];
+
+        foreach ($keys as $key) {
+            $this->isValidKey($key);
+            $items[$key] = $this->hasItem($key) ? clone $this->items[$key] : new Item($key);
+        }
+
+        return $items;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasItem($key)
+    {
+        $this->isValidKey($key);
+
+        return isset($this->items[$key]) && $this->items[$key]->isHit();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function clear()
+    {
+        $this->items = [];
+        $this->deferred = [];
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteItem($key)
+    {
+        return $this->deleteItems([$key]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteItems(array $keys)
+    {
+        array_walk($keys, [$this, 'isValidKey']);
+
+        foreach ($keys as $key) {
+            unset($this->items[$key]);
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function save(CacheItemInterface $item)
+    {
+        $this->items[$item->getKey()] = $item;
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function saveDeferred(CacheItemInterface $item)
+    {
+        $this->deferredItems[$item->getKey()] = $item;
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function commit()
+    {
+        foreach ($this->deferredItems as $item) {
+            $this->save($item);
+        }
+
+        $this->deferredItems = [];
+
+        return true;
+    }
+
+    /**
+     * Determines if the provided key is valid.
+     *
+     * @param string $key
+     * @return bool
+     * @throws InvalidArgumentException
+     */
+    private function isValidKey($key)
+    {
+        $invalidCharacters = '{}()/\\\\@:';
+
+        if (!is_string($key) || preg_match("#[$invalidCharacters]#", $key)) {
+            throw new InvalidArgumentException('The provided key is not valid: ' . var_export($key, true));
+        }
+
+        return true;
+    }
+}

--- a/src/CacheTrait.php
+++ b/src/CacheTrait.php
@@ -23,13 +23,13 @@ trait CacheTrait
      * Gets the cached value if it is present in the cache when that is
      * available.
      */
-    private function getCachedValue()
+    private function getCachedValue($k)
     {
         if (is_null($this->cache)) {
             return;
         }
 
-        $key = $this->getFullCacheKey();
+        $key = $this->getFullCacheKey($k);
         if (is_null($key)) {
             return;
         }
@@ -41,13 +41,13 @@ trait CacheTrait
     /**
      * Saves the value in the cache when that is available.
      */
-    private function setCachedValue($v)
+    private function setCachedValue($k, $v)
     {
         if (is_null($this->cache)) {
             return;
         }
 
-        $key = $this->getFullCacheKey();
+        $key = $this->getFullCacheKey($k);
         if (is_null($key)) {
             return;
         }
@@ -58,19 +58,13 @@ trait CacheTrait
         return $this->cache->save($cacheItem);
     }
 
-    private function getFullCacheKey()
+    private function getFullCacheKey($key)
     {
-        if (isset($this->fetcher)) {
-            $fetcherKey = $this->fetcher->getCacheKey();
-        } else {
-            $fetcherKey = $this->getCacheKey();
-        }
-
-        if (is_null($fetcherKey)) {
+        if (is_null($key)) {
             return;
         }
 
-        $key = $this->cacheConfig['prefix'] . $fetcherKey;
+        $key = $this->cacheConfig['prefix'] . $key;
 
         // ensure we do not have illegal characters
         return str_replace(['{', '}', '(', ')', '/', '\\', '@', ':'], '-', $key);

--- a/src/Credentials/AppIdentityCredentials.php
+++ b/src/Credentials/AppIdentityCredentials.php
@@ -51,8 +51,6 @@ use Google\Auth\CredentialsLoader;
  */
 class AppIdentityCredentials extends CredentialsLoader
 {
-    const cacheKey = 'GOOGLE_AUTH_PHP_APPIDENTITY';
-
     /**
      * Result of fetchAuthToken.
      *
@@ -139,10 +137,13 @@ class AppIdentityCredentials extends CredentialsLoader
     }
 
     /**
+     * Caching is handled by the underlying AppIdentityService, return empty string
+     * to prevent caching.
+     *
      * @return string
      */
     public function getCacheKey()
     {
-        return self::cacheKey;
+        return '';
     }
 }

--- a/src/FetchAuthTokenCache.php
+++ b/src/FetchAuthTokenCache.php
@@ -1,0 +1,108 @@
+<?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Auth;
+
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * A class to implement caching for any object implementing
+ * FetchAuthTokenInterface
+ */
+class FetchAuthTokenCache implements FetchAuthTokenInterface
+{
+    use CacheTrait;
+
+    /**
+     * @var FetchAuthTokenInterface
+     */
+    private $fetcher;
+
+    /**
+     * @var array
+     */
+    private $cacheConfig;
+
+    /**
+     * @var CacheItemPoolInterface
+     */
+    private $cache;
+
+    public function __construct(
+        FetchAuthTokenInterface $fetcher,
+        array $cacheConfig = null,
+        CacheItemPoolInterface $cache
+    ) {
+        $this->fetcher = $fetcher;
+        $this->cache = $cache;
+        $this->cacheConfig = array_merge([
+            'lifetime' => 1500,
+            'prefix' => '',
+        ], (array) $cacheConfig);
+    }
+
+    /**
+     * Implements FetchAuthTokenInterface#fetchAuthToken.
+     *
+     * Checks the cache for a valid auth token and fetches the auth tokens
+     * from the supplied fetcher.
+     *
+     * @param callable $httpHandler callback which delivers psr7 request
+     *
+     * @return array the response
+     *
+     * @throws \Exception
+     */
+    public function fetchAuthToken(callable $httpHandler = null)
+    {
+        // Use the cached value if its available.
+        //
+        // TODO: correct caching; update the call to setCachedValue to set the expiry
+        // to the value returned with the auth token.
+        //
+        // TODO: correct caching; enable the cache to be cleared.
+        $cacheKey = $this->fetcher->getCacheKey();
+        $cached = $this->getCachedValue($cacheKey);
+        if (!empty($cached)) {
+            return ['access_token' => $cached];
+        }
+
+        $auth_token = $this->fetcher->fetchAuthToken($httpHandler);
+
+        if (isset($auth_token['access_token'])) {
+            $this->setCachedValue($cacheKey, $auth_token['access_token']);
+        }
+
+        return $auth_token;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCacheKey()
+    {
+        return $this->getFullCacheKey($this->fetcher->getCacheKey());
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getLastReceivedToken()
+    {
+        return $this->fetcher->getLastReceivedToken();
+    }
+}

--- a/src/Middleware/ScopedAccessTokenMiddleware.php
+++ b/src/Middleware/ScopedAccessTokenMiddleware.php
@@ -171,14 +171,15 @@ class ScopedAccessTokenMiddleware
      */
     private function fetchToken()
     {
-        $cached = $this->getCachedValue();
+        $cacheKey = $this->getCacheKey();
+        $cached = $this->getCachedValue($cacheKey);
 
         if (!empty($cached)) {
             return $cached;
         }
 
         $token = call_user_func($this->tokenFunc, $this->scopes);
-        $this->setCachedValue($token);
+        $this->setCachedValue($cacheKey, $token);
 
         return $token;
     }

--- a/src/Subscriber/ScopedAccessTokenSubscriber.php
+++ b/src/Subscriber/ScopedAccessTokenSubscriber.php
@@ -162,14 +162,15 @@ class ScopedAccessTokenSubscriber implements SubscriberInterface
      */
     private function fetchToken()
     {
-        $cached = $this->getCachedValue();
+        $cacheKey = $this->getCacheKey();
+        $cached = $this->getCachedValue($cacheKey);
 
         if (!empty($cached)) {
             return $cached;
         }
 
         $token = call_user_func($this->tokenFunc, $this->scopes);
-        $this->setCachedValue($token);
+        $this->setCachedValue($cacheKey, $token);
 
         return $token;
     }

--- a/tests/Cache/ItemTest.php
+++ b/tests/Cache/ItemTest.php
@@ -1,0 +1,125 @@
+<?php
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Auth\Tests;
+
+use Google\Auth\Cache\Item;
+
+class ItemTest extends \PHPUnit_Framework_TestCase
+{
+    public function getItem($key)
+    {
+        return new Item($key);
+    }
+
+    public function testGetsKey()
+    {
+        $key = 'item';
+
+        $this->assertEquals($key, $this->getItem($key)->getKey());
+    }
+
+    public function testGetsNull()
+    {
+        $item = $this->getItem('item');
+
+        $this->assertNull($item->get());
+        $this->assertFalse($item->isHit());
+    }
+
+    public function testGetsValue()
+    {
+        $value = 'value';
+        $item = $this->getItem('item');
+        $item->set($value);
+
+        $this->assertEquals('value', $item->get());
+    }
+
+    /**
+     * @dataProvider values
+     */
+    public function testSetsValue($value)
+    {
+        $item = $this->getItem('item');
+        $item->set($value);
+
+        $this->assertEquals($value, $item->get());
+    }
+
+    public function values()
+    {
+        return [
+            [1],
+            [1.5],
+            [true],
+            [null],
+            [new \DateTime()],
+            [['test']],
+            ['value']
+        ];
+    }
+
+    public function testIsHit()
+    {
+        $item = $this->getItem('item');
+
+        $this->assertFalse($item->isHit());
+
+        $item->set('value');
+
+        $this->assertTrue($item->isHit());
+    }
+
+    public function testExpiresAt()
+    {
+        $item = $this->getItem('item');
+        $item->set('value');
+        $item->expiresAt(new \DateTime('now + 1 hour'));
+
+        $this->assertTrue($item->isHit());
+
+        $item->expiresAt(null);
+
+        $this->assertTrue($item->isHit());
+
+        $item->expiresAt(new \DateTime('yesterday'));
+
+        $this->assertFalse($item->isHit());
+    }
+
+    public function testExpiresAfter()
+    {
+        $item = $this->getItem('item');
+        $item->set('value');
+        $item->expiresAfter(30);
+
+        $this->assertTrue($item->isHit());
+
+        $item->expiresAfter(0);
+
+        $this->assertFalse($item->isHit());
+
+        $item->expiresAfter(new \DateInterval('PT30S'));
+
+        $this->assertTrue($item->isHit());
+
+        $item->expiresAfter(null);
+
+        $this->assertTrue($item->isHit());
+    }
+}

--- a/tests/Cache/MemoryCacheItemPoolTest.php
+++ b/tests/Cache/MemoryCacheItemPoolTest.php
@@ -1,0 +1,189 @@
+<?php
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Auth\Tests;
+
+use Google\Auth\Cache\MemoryCacheItemPool;
+use Psr\Cache\InvalidArgumentException;
+
+class MemoryCacheItemPoolTest extends \PHPUnit_Framework_TestCase
+{
+    private $pool;
+
+    public function setUp()
+    {
+        $this->pool = new MemoryCacheItemPool();
+    }
+
+    public function saveItem($key, $value)
+    {
+        $item = $this->pool->getItem($key);
+        $item->set($value);
+        $this->assertTrue($this->pool->save($item));
+
+        return $item;
+    }
+
+    public function testGetsFreshItem()
+    {
+        $item = $this->pool->getItem('item');
+
+        $this->assertInstanceOf('Google\Auth\Cache\Item', $item);
+        $this->assertNull($item->get());
+        $this->assertFalse($item->isHit());
+    }
+
+    public function testGetsExistingItem()
+    {
+        $key = 'item';
+        $value = 'value';
+        $this->saveItem($key, $value);
+        $item = $this->pool->getItem($key);
+
+        $this->assertInstanceOf('Google\Auth\Cache\Item', $item);
+        $this->assertEquals($value, $item->get());
+        $this->assertTrue($item->isHit());
+    }
+
+    public function testGetsMultipleItems()
+    {
+        $keys = ['item1', 'item2'];
+        $items = $this->pool->getItems($keys);
+
+        $this->assertEquals($keys, array_keys($items));
+        $this->assertContainsOnlyInstancesOf('Google\Auth\Cache\Item', $items);
+    }
+
+    public function testHasItem()
+    {
+        $existsKey = 'does-exist';
+        $this->saveItem($existsKey, 'value');
+
+        $this->assertTrue($this->pool->hasItem($existsKey));
+        $this->assertFalse($this->pool->hasItem('does-not-exist'));
+    }
+
+    public function testClear()
+    {
+        $key = 'item';
+        $this->saveItem($key, 'value');
+
+        $this->assertTrue($this->pool->hasItem($key));
+        $this->assertTrue($this->pool->clear());
+        $this->assertFalse($this->pool->hasItem($key));
+    }
+
+    public function testDeletesItem()
+    {
+        $key = 'item';
+        $this->saveItem($key, 'value');
+
+        $this->assertTrue($this->pool->deleteItem($key));
+        $this->assertFalse($this->pool->hasItem($key));
+    }
+
+    public function testDeletesItems()
+    {
+        $keys = ['item1', 'item2'];
+
+        foreach ($keys as $key) {
+            $this->saveItem($key, 'value');
+        }
+
+        $this->assertTrue($this->pool->deleteItems($keys));
+        $this->assertFalse($this->pool->hasItem($keys[0]));
+        $this->assertFalse($this->pool->hasItem($keys[1]));
+    }
+
+    public function testDoesNotDeleteItemsWithInvalidKey()
+    {
+        $keys = ['item1', '{item2}', 'item3'];
+        $value = 'value';
+        $this->saveItem($keys[0], $value);
+        $this->saveItem($keys[2], $value);
+
+        try {
+            $this->pool->deleteItems($keys);
+        } catch (InvalidArgumentException $ex) {
+            // continue execution
+        }
+
+        $this->assertTrue($this->pool->hasItem($keys[0]));
+        $this->assertTrue($this->pool->hasItem($keys[2]));
+    }
+
+    public function testSavesItem()
+    {
+        $key = 'item';
+        $this->saveItem($key, 'value');
+
+        $this->assertTrue($this->pool->hasItem($key));
+    }
+
+    public function testSavesDeferredItem()
+    {
+        $item = $this->pool->getItem('item');
+        $this->assertTrue($this->pool->saveDeferred($item));
+    }
+
+    public function testCommitsDeferredItems()
+    {
+        $keys = ['item1', 'item2'];
+
+        foreach ($keys as $key) {
+            $item = $this->pool->getItem($key);
+            $item->set('value');
+            $this->pool->saveDeferred($item);
+        }
+
+        $this->assertTrue($this->pool->commit());
+        $this->assertTrue($this->pool->hasItem($keys[0]));
+        $this->assertTrue($this->pool->hasItem($keys[1]));
+    }
+
+    /**
+     * @expectedException \Psr\Cache\InvalidArgumentException
+     * @dataProvider invalidKeys
+     */
+    public function testCheckInvalidKeys($key)
+    {
+        $this->pool->getItem($key);
+        $this->pool->getItems([$key]);
+        $this->pool->hasItem($key);
+        $this->pool->deleteItem($key);
+        $this->pool->deleteItems([$key]);
+    }
+
+    public function invalidKeys()
+    {
+        return [
+            [1],
+            [true],
+            [null],
+            [new \DateTime()],
+            ['{'],
+            ['}'],
+            ['('],
+            [')'],
+            ['/'],
+            ['\\'],
+            ['@'],
+            [':'],
+            [[]]
+        ];
+    }
+}

--- a/tests/Credentials/AppIndentityCredentialsTest.php
+++ b/tests/Credentials/AppIndentityCredentialsTest.php
@@ -37,10 +37,10 @@ class AppIdentityCredentialsOnAppEngineTest extends \PHPUnit_Framework_TestCase
 
 class AppIdentityCredentialsGetCacheKeyTest extends \PHPUnit_Framework_TestCase
 {
-    public function testShouldNotBeEmpty()
+    public function testShouldBeEmpty()
     {
         $g = new AppIdentityCredentials();
-        $this->assertNotEmpty($g->getCacheKey());
+        $this->assertEmpty($g->getCacheKey());
     }
 }
 

--- a/tests/FetchAuthTokenCacheTest.php
+++ b/tests/FetchAuthTokenCacheTest.php
@@ -1,0 +1,146 @@
+<?php
+/*
+ * Copyright 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Auth\tests;
+
+use Google\Auth\FetchAuthTokenCache;
+
+class FetchAuthTokenCacheTest extends BaseTest
+{
+    protected function setUp()
+    {
+        $this->mockFetcher =
+            $this
+                ->getMockBuilder('Google\Auth\FetchAuthTokenInterface')
+                ->getMock();
+        $this->mockCacheItem =
+            $this
+                ->getMockBuilder('Psr\Cache\CacheItemInterface')
+                ->getMock();
+        $this->mockCache =
+            $this
+                ->getMockBuilder('Psr\Cache\CacheItemPoolInterface')
+                ->getMock();
+    }
+
+    public function testUsesCachedAuthToken()
+    {
+        $cacheKey = 'myKey';
+        $cachedValue = '2/abcdef1234567890';
+        $this->mockCacheItem
+            ->expects($this->once())
+            ->method('get')
+            ->will($this->returnValue($cachedValue));
+        $this->mockCache
+            ->expects($this->once())
+            ->method('getItem')
+            ->with($this->equalTo($cacheKey))
+            ->will($this->returnValue($this->mockCacheItem));
+        $this->mockFetcher
+            ->expects($this->never())
+            ->method('fetchAuthToken');
+        $this->mockFetcher
+            ->expects($this->any())
+            ->method('getCacheKey')
+            ->will($this->returnValue($cacheKey));
+
+        // Run the test.
+        $cachedFetcher = new FetchAuthTokenCache(
+            $this->mockFetcher,
+            null,
+            $this->mockCache
+        );
+        $accessToken = $cachedFetcher->fetchAuthToken();
+        $this->assertEquals($accessToken, ['access_token' => $cachedValue]);
+    }
+
+    public function testGetsCachedAuthTokenUsingCachePrefix()
+    {
+        $prefix = 'test_prefix-';
+        $cacheKey = 'myKey';
+        $cachedValue = '2/abcdef1234567890';
+        $this->mockCacheItem
+            ->expects($this->once())
+            ->method('get')
+            ->will($this->returnValue($cachedValue));
+        $this->mockCache
+            ->expects($this->once())
+            ->method('getItem')
+            ->with($this->equalTo($prefix . $cacheKey))
+            ->will($this->returnValue($this->mockCacheItem));
+        $this->mockFetcher
+            ->expects($this->never())
+            ->method('fetchAuthToken');
+        $this->mockFetcher
+            ->expects($this->any())
+            ->method('getCacheKey')
+            ->will($this->returnValue($cacheKey));
+
+        // Run the test
+        $cachedFetcher = new FetchAuthTokenCache(
+            $this->mockFetcher,
+            ['prefix' => $prefix],
+            $this->mockCache
+        );
+        $accessToken = $cachedFetcher->fetchAuthToken();
+        $this->assertEquals($accessToken, ['access_token' => $cachedValue]);
+    }
+
+    public function testShouldSaveValueInCacheWithCacheOptions()
+    {
+        $prefix = 'test_prefix-';
+        $lifetime = '70707';
+        $cacheKey = 'myKey';
+        $token = '1/abcdef1234567890';
+        $authResult = ['access_token' => $token];
+        $this->mockCacheItem
+            ->expects($this->any())
+            ->method('get')
+            ->will($this->returnValue(null));
+        $this->mockCacheItem
+            ->expects($this->once())
+            ->method('set')
+            ->with($this->equalTo($token))
+            ->will($this->returnValue(false));
+        $this->mockCacheItem
+            ->expects($this->once())
+            ->method('expiresAfter')
+            ->with($this->equalTo($lifetime));
+        $this->mockCache
+            ->expects($this->exactly(2))
+            ->method('getItem')
+            ->with($this->equalTo($prefix . $cacheKey))
+            ->will($this->returnValue($this->mockCacheItem));
+        $this->mockFetcher
+            ->expects($this->any())
+            ->method('getCacheKey')
+            ->will($this->returnValue($cacheKey));
+        $this->mockFetcher
+            ->expects($this->once())
+            ->method('fetchAuthToken')
+            ->will($this->returnValue($authResult));
+
+        // Run the test
+        $cachedFetcher = new FetchAuthTokenCache(
+            $this->mockFetcher,
+            ['prefix' => $prefix, 'lifetime' => $lifetime],
+            $this->mockCache
+        );
+        $accessToken = $cachedFetcher->fetchAuthToken();
+        $this->assertEquals($accessToken, ['access_token' => $token]);
+    }
+}

--- a/tests/FetchAuthTokenTest.php
+++ b/tests/FetchAuthTokenTest.php
@@ -1,4 +1,19 @@
 <?php
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 namespace Google\Auth\tests;
 

--- a/tests/Middleware/AuthTokenMiddlewareTest.php
+++ b/tests/Middleware/AuthTokenMiddlewareTest.php
@@ -17,6 +17,7 @@
 
 namespace Google\Auth\Tests;
 
+use Google\Auth\FetchAuthTokenCache;
 use Google\Auth\Middleware\AuthTokenMiddleware;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
@@ -134,7 +135,12 @@ class AuthTokenMiddlewareTest extends BaseTest
             ->will($this->returnValue($this->mockRequest));
 
         // Run the test.
-        $middleware = new AuthTokenMiddleware($this->mockFetcher, [], $this->mockCache);
+        $cachedFetcher = new FetchAuthTokenCache(
+            $this->mockFetcher,
+            null,
+            $this->mockCache
+        );
+        $middleware = new AuthTokenMiddleware($cachedFetcher);
         $mock = new MockHandler([new Response(200)]);
         $callable = $middleware($mock);
         $callable($this->mockRequest, ['auth' => 'google_auth']);
@@ -168,11 +174,12 @@ class AuthTokenMiddlewareTest extends BaseTest
             ->will($this->returnValue($this->mockRequest));
 
         // Run the test.
-        $middleware = new AuthTokenMiddleware(
+        $cachedFetcher = new FetchAuthTokenCache(
             $this->mockFetcher,
             ['prefix' => $prefix],
             $this->mockCache
         );
+        $middleware = new AuthTokenMiddleware($cachedFetcher);
         $mock = new MockHandler([new Response(200)]);
         $callable = $middleware($mock);
         $callable($this->mockRequest, ['auth' => 'google_auth']);
@@ -218,11 +225,12 @@ class AuthTokenMiddlewareTest extends BaseTest
             ->will($this->returnValue($this->mockRequest));
 
         // Run the test.
-        $middleware = new AuthTokenMiddleware(
+        $cachedFetcher = new FetchAuthTokenCache(
             $this->mockFetcher,
             ['prefix' => $prefix, 'lifetime' => $lifetime],
             $this->mockCache
         );
+        $middleware = new AuthTokenMiddleware($cachedFetcher);
         $mock = new MockHandler([new Response(200)]);
         $callable = $middleware($mock);
         $callable($this->mockRequest, ['auth' => 'google_auth']);
@@ -262,10 +270,13 @@ class AuthTokenMiddlewareTest extends BaseTest
         MiddlewareCallback::$called = false;
 
         // Run the test.
-        $middleware = new AuthTokenMiddleware(
+        $cachedFetcher = new FetchAuthTokenCache(
             $this->mockFetcher,
             ['prefix' => $prefix],
-            $this->mockCache,
+            $this->mockCache
+        );
+        $middleware = new AuthTokenMiddleware(
+            $cachedFetcher,
             null,
             $tokenCallback
         );

--- a/tests/Subscriber/AuthTokenSubscriberTest.php
+++ b/tests/Subscriber/AuthTokenSubscriberTest.php
@@ -17,6 +17,7 @@
 
 namespace Google\Auth\Tests;
 
+use Google\Auth\FetchAuthTokenCache;
 use Google\Auth\Subscriber\AuthTokenSubscriber;
 use GuzzleHttp\Client;
 use GuzzleHttp\Event\BeforeEvent;
@@ -48,13 +49,13 @@ class AuthTokenSubscriberTest extends BaseTest
 
     public function testSubscribesToEvents()
     {
-        $a = new AuthTokenSubscriber($this->mockFetcher, array());
+        $a = new AuthTokenSubscriber($this->mockFetcher);
         $this->assertArrayHasKey('before', $a->getEvents());
     }
 
     public function testOnlyTouchesWhenAuthConfigScoped()
     {
-        $s = new AuthTokenSubscriber($this->mockFetcher, array());
+        $s = new AuthTokenSubscriber($this->mockFetcher);
         $client = new Client();
         $request = $client->createRequest('GET', 'http://testing.org',
             ['auth' => 'not_google_auth']);
@@ -72,7 +73,7 @@ class AuthTokenSubscriberTest extends BaseTest
             ->will($this->returnValue($authResult));
 
         // Run the test.
-        $a = new AuthTokenSubscriber($this->mockFetcher, array());
+        $a = new AuthTokenSubscriber($this->mockFetcher);
         $client = new Client();
         $request = $client->createRequest('GET', 'http://testing.org',
             ['auth' => 'google_auth']);
@@ -91,7 +92,7 @@ class AuthTokenSubscriberTest extends BaseTest
             ->will($this->returnValue($authResult));
 
         // Run the test.
-        $a = new AuthTokenSubscriber($this->mockFetcher, array());
+        $a = new AuthTokenSubscriber($this->mockFetcher);
         $client = new Client();
         $request = $client->createRequest('GET', 'http://testing.org',
             ['auth' => 'google_auth']);
@@ -122,7 +123,12 @@ class AuthTokenSubscriberTest extends BaseTest
             ->will($this->returnValue($cacheKey));
 
         // Run the test.
-        $a = new AuthTokenSubscriber($this->mockFetcher, array(), $this->mockCache);
+        $cachedFetcher = new FetchAuthTokenCache(
+            $this->mockFetcher,
+            null,
+            $this->mockCache
+        );
+        $a = new AuthTokenSubscriber($cachedFetcher);
         $client = new Client();
         $request = $client->createRequest('GET', 'http://testing.org',
             ['auth' => 'google_auth']);
@@ -155,9 +161,12 @@ class AuthTokenSubscriberTest extends BaseTest
             ->will($this->returnValue($cacheKey));
 
         // Run the test
-        $a = new AuthTokenSubscriber($this->mockFetcher,
+        $cachedFetcher = new FetchAuthTokenCache(
+            $this->mockFetcher,
             ['prefix' => $prefix],
-            $this->mockCache);
+            $this->mockCache
+        );
+        $a = new AuthTokenSubscriber($cachedFetcher);
         $client = new Client();
         $request = $client->createRequest('GET', 'http://testing.org',
             ['auth' => 'google_auth']);
@@ -202,10 +211,12 @@ class AuthTokenSubscriberTest extends BaseTest
             ->will($this->returnValue($authResult));
 
         // Run the test
-        $a = new AuthTokenSubscriber($this->mockFetcher,
+        $cachedFetcher = new FetchAuthTokenCache(
+            $this->mockFetcher,
             ['prefix' => $prefix, 'lifetime' => $lifetime],
-            $this->mockCache);
-
+            $this->mockCache
+        );
+        $a = new AuthTokenSubscriber($cachedFetcher);
         $client = new Client();
         $request = $client->createRequest('GET', 'http://testing.org',
             ['auth' => 'google_auth']);
@@ -245,10 +256,13 @@ class AuthTokenSubscriberTest extends BaseTest
         SubscriberCallback::$called = false;
 
         // Run the test
-        $a = new AuthTokenSubscriber(
+        $cachedFetcher = new FetchAuthTokenCache(
             $this->mockFetcher,
             ['prefix' => $prefix],
-            $this->mockCache,
+            $this->mockCache
+        );
+        $a = new AuthTokenSubscriber(
+            $cachedFetcher,
             null,
             $tokenCallback
         );


### PR DESCRIPTION
Addresses #121 

Highlights:
- Adds `FetchAuthTokenCache` wrapper class to implement caching on anything implementing `FetchAuthTokenInterface`.
- Removes caching from all Middleware / Subscriber classes
- Bypasses caching (by setting the key to null) for `AppIdentityCredentials` - Caching here is handled by the [AppIdentityService](https://github.com/GoogleCloudPlatform/appengine-php-sdk/blob/master/google/appengine/api/app_identity/AppIdentityService.php#L168)
- Removes calls to `getCacheKey` from Cache Trait - that function does not exist as part of the trait, and as a result was causing some unexpected problems. The cache key is now explicitly passed in.
