### PR TITLE
Do not overwrite refresh token with null

### DIFF
--- a/src/OAuth2.php
+++ b/src/OAuth2.php
@@ -597,9 +597,9 @@ class OAuth2 implements FetchAuthTokenInterface
 
         $this->setAccessToken($opts['access_token']);
         $this->setIdToken($opts['id_token']);
-        // We expect refresh_token to be unset when an access token is obtained
-        // using a currently valid refresh token - in this case, we do not want
-        // to replace the existing refresh token with null
+        // The refresh token should only be updated if a value is explicitly
+        // passed in, as some access token responses do not include a refresh
+        // token.
         if (array_key_exists('refresh_token', $opts)) {
             $this->setRefreshToken($opts['refresh_token']);
         }

--- a/tests/OAuth2Test.php
+++ b/tests/OAuth2Test.php
@@ -726,6 +726,37 @@ class OAuth2FetchAuthTokenTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('an_id_token', $o->getIdToken());
         $this->assertEquals('a_refresh_token', $o->getRefreshToken());
     }
+
+    public function testUpdatesTokenFieldsOnFetchMissingRefreshToken()
+    {
+        $testConfig = $this->fetchAuthTokenMinimal;
+        $testConfig['refresh_token'] = 'a_refresh_token';
+        $wanted_updates = [
+            'expires_at' => '1',
+            'expires_in' => '57',
+            'issued_at' => '2',
+            'access_token' => 'an_access_token',
+            'id_token' => 'an_id_token',
+        ];
+        $json = json_encode($wanted_updates);
+        $httpHandler = getHandler([
+            buildResponse(200, [], Psr7\stream_for($json)),
+        ]);
+        $o = new OAuth2($testConfig);
+        $this->assertNull($o->getExpiresAt());
+        $this->assertNull($o->getExpiresIn());
+        $this->assertNull($o->getIssuedAt());
+        $this->assertNull($o->getAccessToken());
+        $this->assertNull($o->getIdToken());
+        $this->assertEquals('a_refresh_token', $o->getRefreshToken());
+        $tokens = $o->fetchAuthToken($httpHandler);
+        $this->assertEquals(1, $o->getExpiresAt());
+        $this->assertEquals(57, $o->getExpiresIn());
+        $this->assertEquals(2, $o->getIssuedAt());
+        $this->assertEquals('an_access_token', $o->getAccessToken());
+        $this->assertEquals('an_id_token', $o->getIdToken());
+        $this->assertEquals('a_refresh_token', $o->getRefreshToken());
+    }
 }
 
 class OAuth2VerifyIdTokenTest extends \PHPUnit_Framework_TestCase


### PR DESCRIPTION
Prevent overwriting the refreshToken with null when no refresh token is returned in fetchAuthToken method
Fixes https://github.com/google/google-auth-library-php/issues/130