### PR TITLE
Change authorization header key to lowercase

### DIFF
--- a/src/CredentialsLoader.php
+++ b/src/CredentialsLoader.php
@@ -30,7 +30,7 @@ abstract class CredentialsLoader implements FetchAuthTokenInterface
     const ENV_VAR = 'GOOGLE_APPLICATION_CREDENTIALS';
     const WELL_KNOWN_PATH = 'gcloud/application_default_credentials.json';
     const NON_WINDOWS_WELL_KNOWN_PATH_BASE = '.config';
-    const AUTH_METADATA_KEY = 'Authorization';
+    const AUTH_METADATA_KEY = 'authorization';
 
     /**
      * @param string $cause

--- a/src/Middleware/AuthTokenMiddleware.php
+++ b/src/Middleware/AuthTokenMiddleware.php
@@ -29,7 +29,7 @@ use Psr\Http\Message\RequestInterface;
  *
  * Requests will be accessed with the authorization header:
  *
- * 'Authorization' 'Bearer <value of auth_token>'
+ * 'authorization' 'Bearer <value of auth_token>'
  */
 class AuthTokenMiddleware
 {
@@ -99,7 +99,7 @@ class AuthTokenMiddleware
                 return $handler($request, $options);
             }
 
-            $request = $request->withHeader('Authorization', 'Bearer ' . $this->fetchToken());
+            $request = $request->withHeader('authorization', 'Bearer ' . $this->fetchToken());
 
             return $handler($request, $options);
         };

--- a/src/Middleware/ScopedAccessTokenMiddleware.php
+++ b/src/Middleware/ScopedAccessTokenMiddleware.php
@@ -31,7 +31,7 @@ use Psr\Http\Message\RequestInterface;
  *
  * Requests will be accessed with the authorization header:
  *
- * 'Authorization' 'Bearer <value of auth_token>'
+ * 'authorization' 'Bearer <value of auth_token>'
  */
 class ScopedAccessTokenMiddleware
 {
@@ -130,7 +130,7 @@ class ScopedAccessTokenMiddleware
                 return $handler($request, $options);
             }
 
-            $request = $request->withHeader('Authorization', 'Bearer ' . $this->fetchToken());
+            $request = $request->withHeader('authorization', 'Bearer ' . $this->fetchToken());
 
             return $handler($request, $options);
         };

--- a/src/Subscriber/AuthTokenSubscriber.php
+++ b/src/Subscriber/AuthTokenSubscriber.php
@@ -31,7 +31,7 @@ use GuzzleHttp\Event\SubscriberInterface;
  *
  * Requests will be accessed with the authorization header:
  *
- * 'Authorization' 'Bearer <value of auth_token>'
+ * 'authorization' 'Bearer <value of auth_token>'
  */
 class AuthTokenSubscriber implements SubscriberInterface
 {
@@ -107,7 +107,7 @@ class AuthTokenSubscriber implements SubscriberInterface
         // Fetch the auth token.
         $auth_tokens = $this->fetcher->fetchAuthToken($this->httpHandler);
         if (array_key_exists('access_token', $auth_tokens)) {
-            $request->setHeader('Authorization', 'Bearer ' . $auth_tokens['access_token']);
+            $request->setHeader('authorization', 'Bearer ' . $auth_tokens['access_token']);
 
             // notify the callback if applicable
             if ($this->tokenCallback) {

--- a/src/Subscriber/ScopedAccessTokenSubscriber.php
+++ b/src/Subscriber/ScopedAccessTokenSubscriber.php
@@ -33,7 +33,7 @@ use Psr\Cache\CacheItemPoolInterface;
  *
  * Requests will be accessed with the authorization header:
  *
- * 'Authorization' 'Bearer <access token obtained from the closure>'
+ * 'authorization' 'Bearer <access token obtained from the closure>'
  */
 class ScopedAccessTokenSubscriber implements SubscriberInterface
 {
@@ -135,7 +135,7 @@ class ScopedAccessTokenSubscriber implements SubscriberInterface
             return;
         }
         $auth_header = 'Bearer ' . $this->fetchToken();
-        $request->setHeader('Authorization', $auth_header);
+        $request->setHeader('authorization', $auth_header);
     }
 
     /**

--- a/tests/Middleware/AuthTokenMiddlewareTest.php
+++ b/tests/Middleware/AuthTokenMiddlewareTest.php
@@ -78,7 +78,7 @@ class AuthTokenMiddlewareTest extends BaseTest
         $this->mockRequest
             ->expects($this->once())
             ->method('withHeader')
-            ->with('Authorization', 'Bearer ' . $authResult['access_token'])
+            ->with('authorization', 'Bearer ' . $authResult['access_token'])
             ->will($this->returnValue($this->mockRequest));
 
         // Run the test.
@@ -98,7 +98,7 @@ class AuthTokenMiddlewareTest extends BaseTest
         $this->mockRequest
             ->expects($this->once())
             ->method('withHeader')
-            ->with('Authorization', 'Bearer ')
+            ->with('authorization', 'Bearer ')
             ->will($this->returnValue($this->mockRequest));
 
         // Run the test.
@@ -131,7 +131,7 @@ class AuthTokenMiddlewareTest extends BaseTest
         $this->mockRequest
             ->expects($this->once())
             ->method('withHeader')
-            ->with('Authorization', 'Bearer ' . $cachedValue)
+            ->with('authorization', 'Bearer ' . $cachedValue)
             ->will($this->returnValue($this->mockRequest));
 
         // Run the test.
@@ -170,7 +170,7 @@ class AuthTokenMiddlewareTest extends BaseTest
         $this->mockRequest
             ->expects($this->once())
             ->method('withHeader')
-            ->with('Authorization', 'Bearer ' . $cachedValue)
+            ->with('authorization', 'Bearer ' . $cachedValue)
             ->will($this->returnValue($this->mockRequest));
 
         // Run the test.
@@ -221,7 +221,7 @@ class AuthTokenMiddlewareTest extends BaseTest
         $this->mockRequest
             ->expects($this->once())
             ->method('withHeader')
-            ->with('Authorization', 'Bearer ' . $token)
+            ->with('authorization', 'Bearer ' . $token)
             ->will($this->returnValue($this->mockRequest));
 
         // Run the test.

--- a/tests/Middleware/ScopedAccessTokenMiddlewareTest.php
+++ b/tests/Middleware/ScopedAccessTokenMiddlewareTest.php
@@ -68,7 +68,7 @@ class ScopedAccessTokenMiddlewareTest extends BaseTest
         $this->mockRequest
             ->expects($this->once())
             ->method('withHeader')
-            ->with('Authorization', 'Bearer ' . $token)
+            ->with('authorization', 'Bearer ' . $token)
             ->will($this->returnValue($this->mockRequest));
 
         // Run the test
@@ -96,7 +96,7 @@ class ScopedAccessTokenMiddlewareTest extends BaseTest
         $this->mockRequest
             ->expects($this->once())
             ->method('withHeader')
-            ->with('Authorization', 'Bearer ' . $cachedValue)
+            ->with('authorization', 'Bearer ' . $cachedValue)
             ->will($this->returnValue($this->mockRequest));
 
         // Run the test
@@ -130,7 +130,7 @@ class ScopedAccessTokenMiddlewareTest extends BaseTest
         $this->mockRequest
             ->expects($this->once())
             ->method('withHeader')
-            ->with('Authorization', 'Bearer ' . $cachedValue)
+            ->with('authorization', 'Bearer ' . $cachedValue)
             ->will($this->returnValue($this->mockRequest));
 
         // Run the test
@@ -168,7 +168,7 @@ class ScopedAccessTokenMiddlewareTest extends BaseTest
         $this->mockRequest
             ->expects($this->once())
             ->method('withHeader')
-            ->with('Authorization', 'Bearer ' . $token)
+            ->with('authorization', 'Bearer ' . $token)
             ->will($this->returnValue($this->mockRequest));
 
         // Run the test
@@ -212,7 +212,7 @@ class ScopedAccessTokenMiddlewareTest extends BaseTest
         $this->mockRequest
             ->expects($this->once())
             ->method('withHeader')
-            ->with('Authorization', 'Bearer ' . $token)
+            ->with('authorization', 'Bearer ' . $token)
             ->will($this->returnValue($this->mockRequest));
 
         // Run the test

--- a/tests/Subscriber/AuthTokenSubscriberTest.php
+++ b/tests/Subscriber/AuthTokenSubscriberTest.php
@@ -61,7 +61,7 @@ class AuthTokenSubscriberTest extends BaseTest
             ['auth' => 'not_google_auth']);
         $before = new BeforeEvent(new Transaction($client, $request));
         $s->onBefore($before);
-        $this->assertSame($request->getHeader('Authorization'), '');
+        $this->assertSame($request->getHeader('authorization'), '');
     }
 
     public function testAddsTheTokenAsAnAuthorizationHeader()
@@ -79,7 +79,7 @@ class AuthTokenSubscriberTest extends BaseTest
             ['auth' => 'google_auth']);
         $before = new BeforeEvent(new Transaction($client, $request));
         $a->onBefore($before);
-        $this->assertSame($request->getHeader('Authorization'),
+        $this->assertSame($request->getHeader('authorization'),
             'Bearer 1/abcdef1234567890');
     }
 
@@ -98,7 +98,7 @@ class AuthTokenSubscriberTest extends BaseTest
             ['auth' => 'google_auth']);
         $before = new BeforeEvent(new Transaction($client, $request));
         $a->onBefore($before);
-        $this->assertSame($request->getHeader('Authorization'), '');
+        $this->assertSame($request->getHeader('authorization'), '');
     }
 
     public function testUsesCachedAuthToken()
@@ -134,7 +134,7 @@ class AuthTokenSubscriberTest extends BaseTest
             ['auth' => 'google_auth']);
         $before = new BeforeEvent(new Transaction($client, $request));
         $a->onBefore($before);
-        $this->assertSame($request->getHeader('Authorization'),
+        $this->assertSame($request->getHeader('authorization'),
             'Bearer 2/abcdef1234567890');
     }
 
@@ -172,7 +172,7 @@ class AuthTokenSubscriberTest extends BaseTest
             ['auth' => 'google_auth']);
         $before = new BeforeEvent(new Transaction($client, $request));
         $a->onBefore($before);
-        $this->assertSame($request->getHeader('Authorization'),
+        $this->assertSame($request->getHeader('authorization'),
             'Bearer 2/abcdef1234567890');
     }
 
@@ -222,7 +222,7 @@ class AuthTokenSubscriberTest extends BaseTest
             ['auth' => 'google_auth']);
         $before = new BeforeEvent(new Transaction($client, $request));
         $a->onBefore($before);
-        $this->assertSame($request->getHeader('Authorization'),
+        $this->assertSame($request->getHeader('authorization'),
             'Bearer 1/abcdef1234567890');
     }
 

--- a/tests/Subscriber/ScopedAccessTokenSubscriberTest.php
+++ b/tests/Subscriber/ScopedAccessTokenSubscriberTest.php
@@ -82,7 +82,7 @@ class ScopedAccessTokenSubscriberTest extends BaseTest
         $s->onBefore($before);
         $this->assertSame(
             'Bearer 1/abcdef1234567890',
-            $request->getHeader('Authorization')
+            $request->getHeader('authorization')
         );
     }
 
@@ -112,7 +112,7 @@ class ScopedAccessTokenSubscriberTest extends BaseTest
         $s->onBefore($before);
         $this->assertSame(
             'Bearer 2/abcdef1234567890',
-            $request->getHeader('Authorization')
+            $request->getHeader('authorization')
         );
     }
 
@@ -144,7 +144,7 @@ class ScopedAccessTokenSubscriberTest extends BaseTest
         $s->onBefore($before);
         $this->assertSame(
             'Bearer 2/abcdef1234567890',
-            $request->getHeader('Authorization')
+            $request->getHeader('authorization')
         );
     }
 
@@ -177,7 +177,7 @@ class ScopedAccessTokenSubscriberTest extends BaseTest
         $s->onBefore($before);
         $this->assertSame(
             'Bearer 2/abcdef1234567890',
-            $request->getHeader('Authorization')
+            $request->getHeader('authorization')
         );
     }
 
@@ -218,7 +218,7 @@ class ScopedAccessTokenSubscriberTest extends BaseTest
         $s->onBefore($before);
         $this->assertSame(
             'Bearer 2/abcdef1234567890',
-            $request->getHeader('Authorization')
+            $request->getHeader('authorization')
         );
     }
 
@@ -233,6 +233,6 @@ class ScopedAccessTokenSubscriberTest extends BaseTest
             ['auth' => 'notscoped']);
         $before = new BeforeEvent(new Transaction($client, $request));
         $s->onBefore($before);
-        $this->assertSame('', $request->getHeader('Authorization'));
+        $this->assertSame('', $request->getHeader('authorization'));
     }
 }


### PR DESCRIPTION
For issue grpc/grpc#7881

A recent GFE reloadable flag rollout caused a few Cloud APIs to start rejecting some requests from gRPC PHP clients because in some cases, the 'Authorization' header key for the bearer token got directly sent to the server, and it violates HTTP/2 standards. I am hoping we can change the header key to lower case.
