### PR TITLE
Use elseif construct when determining credentials

### DIFF
--- a/src/ApplicationDefaultCredentials.php
+++ b/src/ApplicationDefaultCredentials.php
@@ -143,16 +143,15 @@ class ApplicationDefaultCredentials
         $creds = null;
         $jsonKey = CredentialsLoader::fromEnv()
             ?: CredentialsLoader::fromWellKnownFile();
+
         if (!is_null($jsonKey)) {
             $creds = CredentialsLoader::makeCredentials($scope, $jsonKey);
-        }
-        if (AppIdentityCredentials::onAppEngine() &&
-            !GCECredentials::onAppEngineFlexible()) {
+        } elseif (AppIdentityCredentials::onAppEngine() && !GCECredentials::onAppEngineFlexible()) {
             $creds = new AppIdentityCredentials($scope);
-        }
-        if (GCECredentials::onGce($httpHandler)) {
+        } elseif (GCECredentials::onGce($httpHandler)) {
             $creds = new GCECredentials();
         }
+
         if (is_null($creds)) {
             throw new \DomainException(self::notFound());
         }


### PR DESCRIPTION
Please see: https://github.com/GoogleCloudPlatform/google-cloud-php/issues/156

Requests to the compute engine metadata server appear to time out indefinitely in app engine standard. This will prevent testing for compute engine if we already know we are on app engine.