### PR TITLE
Fix base_url option

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ $stack->push($middleware);
 // create the HTTP client
 $client = new Client([
   'handler' => $stack,
-  'base_url' => 'https://www.googleapis.com',
+  'base_uri' => 'https://www.googleapis.com',
   'auth' => 'google_auth'  // authorize all requests
 ]);
 


### PR DESCRIPTION
The option is called `base_uri`: http://docs.guzzlephp.org/en/latest/quickstart.html