### PR TITLE
Fix for PSR-6 compliance to verify a hit

### DIFF
--- a/src/CacheTrait.php
+++ b/src/CacheTrait.php
@@ -37,7 +37,9 @@ trait CacheTrait
         }
 
         $cacheItem = $this->cache->getItem($key);
-        return $cacheItem->get();
+        if ($cacheItem->isHit()) {
+            return $cacheItem->get();
+        }
     }
 
     /**


### PR DESCRIPTION
Per PSR-6:

> Hit - A cache hit occurs when a Calling Library requests an Item by key and a matching value is found for that key, and that value has not expired, and the value is not invalid for some other reason. Calling Libraries SHOULD make sure to verify isHit() on all get() calls.

The `$cacheItem` response is never validated, and in the case of the recommended Stash library the response contains the expired data (presumably to provide access to the previous cache).

This should fix a recurring issue with authentication when using Stash for storing authentication tokens; which were failing to regenerate properly.  There is one open issue https://github.com/google/google-api-php-client/issues/1075, plus several other closed issues which appear to have misdiagnosed the issue.