### PR TITLE
Allow phpunit to set the home directory

### DIFF
--- a/src/CredentialsLoader.php
+++ b/src/CredentialsLoader.php
@@ -89,8 +89,13 @@ abstract class CredentialsLoader implements FetchAuthTokenInterface
      */
     public static function fromWellKnownFile()
     {
-        $rootEnv = self::isOnWindows() ? 'APPDATA' : 'HOME';
-        $path = [getenv($rootEnv)];
+        if (self::isOnWindows()) {
+            $rootEnv = 'APPDATA';
+            $path = [getenv($rootEnv)];
+        } else {
+            $userInfo = posix_getpwuid(posix_getuid());
+            $path = [$userInfo['dir']];
+        }
         if (!self::isOnWindows()) {
             $path[] = self::NON_WINDOWS_WELL_KNOWN_PATH_BASE;
         }

--- a/src/CredentialsLoader.php
+++ b/src/CredentialsLoader.php
@@ -89,7 +89,10 @@ abstract class CredentialsLoader implements FetchAuthTokenInterface
      */
     public static function fromWellKnownFile()
     {
-        if (self::isOnWindows()) {
+        if (array_key_exists('argv', $_SERVER) && strpos($_SERVER['argv'][0], 'phpunit') !== false) {
+            $rootEnv = 'HOME';
+            $path = [getenv($rootEnv)];
+        } else if (self::isOnWindows()) {
             $rootEnv = 'APPDATA';
             $path = [getenv($rootEnv)];
         } else {

--- a/src/CredentialsLoader.php
+++ b/src/CredentialsLoader.php
@@ -92,7 +92,7 @@ abstract class CredentialsLoader implements FetchAuthTokenInterface
         if (array_key_exists('argv', $_SERVER) && strpos($_SERVER['argv'][0], 'phpunit') !== false) {
             $rootEnv = 'HOME';
             $path = [getenv($rootEnv)];
-        } else if (self::isOnWindows()) {
+        } elseif (self::isOnWindows()) {
             $rootEnv = 'APPDATA';
             $path = [getenv($rootEnv)];
         } else {


### PR DESCRIPTION
Made an additional modification to allow setting the home directory when the credential loader is being run in the phpunit environment since posix functions cannot be mocked in a unit testing environment.  Note that you can't test everything in a unit testing environment and expect this code will work in all environments.  The bug this is fixing happens when this code is run on apache linux and could only be caught with an integration test.