### PR TITLE
Accept a default httpHandler at the construct level in FetchAuthToken

### DIFF
--- a/src/FetchAuthTokenCache.php
+++ b/src/FetchAuthTokenCache.php
@@ -42,10 +42,16 @@ class FetchAuthTokenCache implements FetchAuthTokenInterface
      */
     private $cache;
 
+    /**
+     * @var callable
+     */
+    private $httpHandler;
+
     public function __construct(
         FetchAuthTokenInterface $fetcher,
         array $cacheConfig = null,
-        CacheItemPoolInterface $cache
+        +        CacheItemPoolInterface $cache,
+        +        callable $httpHandler = null
     ) {
         $this->fetcher = $fetcher;
         $this->cache = $cache;
@@ -53,6 +59,7 @@ class FetchAuthTokenCache implements FetchAuthTokenInterface
             'lifetime' => 1500,
             'prefix' => '',
         ], (array) $cacheConfig);
+        $this->httpHandler = $httpHandler;
     }
 
     /**
@@ -79,6 +86,10 @@ class FetchAuthTokenCache implements FetchAuthTokenInterface
         $cached = $this->getCachedValue($cacheKey);
         if (!empty($cached)) {
             return ['access_token' => $cached];
+        }
+
+        if ($httpHandler === null) {
+            $httpHandler = $this->httpHandler;
         }
 
         $auth_token = $this->fetcher->fetchAuthToken($httpHandler);

--- a/src/FetchAuthTokenCache.php
+++ b/src/FetchAuthTokenCache.php
@@ -43,7 +43,7 @@ class FetchAuthTokenCache implements FetchAuthTokenInterface
     private $cache;
 
     /**
-     * @var callable
+     * @var callable|null
      */
     private $httpHandler;
 

--- a/src/FetchAuthTokenCache.php
+++ b/src/FetchAuthTokenCache.php
@@ -50,8 +50,8 @@ class FetchAuthTokenCache implements FetchAuthTokenInterface
     public function __construct(
         FetchAuthTokenInterface $fetcher,
         array $cacheConfig = null,
-        +        CacheItemPoolInterface $cache,
-        +        callable $httpHandler = null
+        CacheItemPoolInterface $cache,
+        callable $httpHandler = null
     ) {
         $this->fetcher = $fetcher;
         $this->cache = $cache;


### PR DESCRIPTION
I've been trying to make this work:

```php
$httpHandler = HttpHandlerFactory::build(new GuzzleHttp\Client([
    'timeout' => 1.0,
    'connect_timeout' => 0.3,
    'read_timeout' => 0.7
]);
$client = new SpannerClient([
    'authHttpHandler' => $httpHandler
]);
```

From a high level this doesn't work because in [gax-php GrpcCredentialsHelper.php](https://github.com/googleapis/gax-php/blob/master/src/GrpcCredentialsHelper.php#L133) it does not pass in the `authHttpHandler` function and at a higher level, none of the options get passed into GrpcCredentialsHelper because all of those get set via [getGaxConfig](https://github.com/GoogleCloudPlatform/google-cloud-php/blob/master/src/Spanner/Connection/Grpc.php#L153) and include none of the higher level configuration.

This fix works by setting the httpHandler in the construction of [FetchAuthTokenCache](https://github.com/GoogleCloudPlatform/google-cloud-php/pull/692/files#diff-d24fa15bc71079d398ddee7a482091ccR153).

Related: https://github.com/GoogleCloudPlatform/google-cloud-php/pull/692