### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "psr/cache": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "3.7.*",
+    "phpunit/phpunit": "^4.8.36",
     "friendsofphp/php-cs-fixer": "^1.11"
   },
   "autoload": {

--- a/tests/ApplicationDefaultCredentialsTest.php
+++ b/tests/ApplicationDefaultCredentialsTest.php
@@ -21,8 +21,9 @@ use Google\Auth\ApplicationDefaultCredentials;
 use Google\Auth\Credentials\GCECredentials;
 use Google\Auth\Credentials\ServiceAccountCredentials;
 use GuzzleHttp\Psr7;
+use PHPUnit\Framework\TestCase;
 
-class ADCGetTest extends \PHPUnit_Framework_TestCase
+class ADCGetTest extends TestCase
 {
     private $originalHome;
 
@@ -101,7 +102,7 @@ class ADCGetTest extends \PHPUnit_Framework_TestCase
     }
 }
 
-class ADCGetMiddlewareTest extends \PHPUnit_Framework_TestCase
+class ADCGetMiddlewareTest extends TestCase
 {
     private $originalHome;
 

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -3,8 +3,9 @@
 namespace Google\Auth\tests;
 
 use GuzzleHttp\ClientInterface;
+use PHPUnit\Framework\TestCase;
 
-abstract class BaseTest extends \PHPUnit_Framework_TestCase
+abstract class BaseTest extends TestCase
 {
     public function onlyGuzzle6()
     {

--- a/tests/Cache/ItemTest.php
+++ b/tests/Cache/ItemTest.php
@@ -18,8 +18,9 @@
 namespace Google\Auth\Tests;
 
 use Google\Auth\Cache\Item;
+use PHPUnit\Framework\TestCase;
 
-class ItemTest extends \PHPUnit_Framework_TestCase
+class ItemTest extends TestCase
 {
     public function getItem($key)
     {

--- a/tests/Cache/MemoryCacheItemPoolTest.php
+++ b/tests/Cache/MemoryCacheItemPoolTest.php
@@ -18,9 +18,10 @@
 namespace Google\Auth\Tests;
 
 use Google\Auth\Cache\MemoryCacheItemPool;
+use PHPUnit\Framework\TestCase;
 use Psr\Cache\InvalidArgumentException;
 
-class MemoryCacheItemPoolTest extends \PHPUnit_Framework_TestCase
+class MemoryCacheItemPoolTest extends TestCase
 {
     private $pool;
 

--- a/tests/CacheTraitTest.php
+++ b/tests/CacheTraitTest.php
@@ -18,8 +18,9 @@
 namespace Google\Auth\Tests;
 
 use Google\Auth\CacheTrait;
+use PHPUnit\Framework\TestCase;
 
-class CacheTraitTest extends \PHPUnit_Framework_TestCase
+class CacheTraitTest extends TestCase
 {
     private $mockFetcher;
     private $mockCacheItem;

--- a/tests/Credentials/AppIndentityCredentialsTest.php
+++ b/tests/Credentials/AppIndentityCredentialsTest.php
@@ -20,8 +20,9 @@ namespace Google\Auth\Tests;
 use google\appengine\api\app_identity\AppIdentityService;
 // included from tests\mocks\AppIdentityService.php
 use Google\Auth\Credentials\AppIdentityCredentials;
+use PHPUnit\Framework\TestCase;
 
-class AppIdentityCredentialsOnAppEngineTest extends \PHPUnit_Framework_TestCase
+class AppIdentityCredentialsOnAppEngineTest extends TestCase
 {
     public function testIsFalseByDefault()
     {
@@ -41,7 +42,7 @@ class AppIdentityCredentialsOnAppEngineTest extends \PHPUnit_Framework_TestCase
     }
 }
 
-class AppIdentityCredentialsGetCacheKeyTest extends \PHPUnit_Framework_TestCase
+class AppIdentityCredentialsGetCacheKeyTest extends TestCase
 {
     public function testShouldBeEmpty()
     {
@@ -50,7 +51,7 @@ class AppIdentityCredentialsGetCacheKeyTest extends \PHPUnit_Framework_TestCase
     }
 }
 
-class AppIdentityCredentialsFetchAuthTokenTest extends \PHPUnit_Framework_TestCase
+class AppIdentityCredentialsFetchAuthTokenTest extends TestCase
 {
     public function testShouldBeEmptyIfNotOnAppEngine()
     {

--- a/tests/Credentials/GCECredentialsTest.php
+++ b/tests/Credentials/GCECredentialsTest.php
@@ -20,8 +20,9 @@ namespace Google\Auth\Tests;
 use Google\Auth\Credentials\GCECredentials;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
-class GCECredentialsOnGCETest extends \PHPUnit_Framework_TestCase
+class GCECredentialsOnGCETest extends TestCase
 {
     public function testIsFalseOnClientErrorStatus()
     {
@@ -56,7 +57,7 @@ class GCECredentialsOnGCETest extends \PHPUnit_Framework_TestCase
     }
 }
 
-class GCECredentialsOnAppEngineFlexibleTest extends \PHPUnit_Framework_TestCase
+class GCECredentialsOnAppEngineFlexibleTest extends TestCase
 {
     public function testIsFalseByDefault()
     {
@@ -70,7 +71,7 @@ class GCECredentialsOnAppEngineFlexibleTest extends \PHPUnit_Framework_TestCase
     }
 }
 
-class GCECredentialsGetCacheKeyTest extends \PHPUnit_Framework_TestCase
+class GCECredentialsGetCacheKeyTest extends TestCase
 {
     public function testShouldNotBeEmpty()
     {
@@ -79,7 +80,7 @@ class GCECredentialsGetCacheKeyTest extends \PHPUnit_Framework_TestCase
     }
 }
 
-class GCECredentialsFetchAuthTokenTest extends \PHPUnit_Framework_TestCase
+class GCECredentialsFetchAuthTokenTest extends TestCase
 {
     public function testShouldBeEmptyIfNotOnGCE()
     {

--- a/tests/Credentials/IAMCredentialsTest.php
+++ b/tests/Credentials/IAMCredentialsTest.php
@@ -18,8 +18,9 @@
 namespace Google\Auth\Tests;
 
 use Google\Auth\Credentials\IAMCredentials;
+use PHPUnit\Framework\TestCase;
 
-class IAMConstructorTest extends \PHPUnit_Framework_TestCase
+class IAMConstructorTest extends TestCase
 {
     /**
      * @expectedException InvalidArgumentException
@@ -53,7 +54,7 @@ class IAMConstructorTest extends \PHPUnit_Framework_TestCase
     }
 }
 
-class IAMUpdateMetadataCallbackTest extends \PHPUnit_Framework_TestCase
+class IAMUpdateMetadataCallbackTest extends TestCase
 {
     public function testUpdateMetadataFunc()
     {

--- a/tests/Credentials/ServiceAccountCredentialsTest.php
+++ b/tests/Credentials/ServiceAccountCredentialsTest.php
@@ -23,6 +23,7 @@ use Google\Auth\Credentials\ServiceAccountJwtAccessCredentials;
 use Google\Auth\CredentialsLoader;
 use Google\Auth\OAuth2;
 use GuzzleHttp\Psr7;
+use PHPUnit\Framework\TestCase;
 
 // Creates a standard JSON auth object for testing.
 function createTestJson()
@@ -36,7 +37,7 @@ function createTestJson()
     ];
 }
 
-class SACGetCacheKeyTest extends \PHPUnit_Framework_TestCase
+class SACGetCacheKeyTest extends TestCase
 {
     public function testShouldBeTheSameAsOAuth2WithTheSameScope()
     {
@@ -87,7 +88,7 @@ class SACGetCacheKeyTest extends \PHPUnit_Framework_TestCase
     }
 }
 
-class SACConstructorTest extends \PHPUnit_Framework_TestCase
+class SACConstructorTest extends TestCase
 {
     /**
      * @expectedException InvalidArgumentException
@@ -148,7 +149,7 @@ class SACConstructorTest extends \PHPUnit_Framework_TestCase
     }
 }
 
-class SACFromEnvTest extends \PHPUnit_Framework_TestCase
+class SACFromEnvTest extends TestCase
 {
     protected function tearDown()
     {
@@ -178,7 +179,7 @@ class SACFromEnvTest extends \PHPUnit_Framework_TestCase
     }
 }
 
-class SACFromWellKnownFileTest extends \PHPUnit_Framework_TestCase
+class SACFromWellKnownFileTest extends TestCase
 {
     private $originalHome;
 
@@ -211,7 +212,7 @@ class SACFromWellKnownFileTest extends \PHPUnit_Framework_TestCase
     }
 }
 
-class SACFetchAuthTokenTest extends \PHPUnit_Framework_TestCase
+class SACFetchAuthTokenTest extends TestCase
 {
     private $privateKey;
 
@@ -307,7 +308,7 @@ class SACFetchAuthTokenTest extends \PHPUnit_Framework_TestCase
     }
 }
 
-class SACJwtAccessTest extends \PHPUnit_Framework_TestCase
+class SACJwtAccessTest extends TestCase
 {
     private $privateKey;
 
@@ -433,7 +434,7 @@ class SACJwtAccessTest extends \PHPUnit_Framework_TestCase
     }
 }
 
-class SACJwtAccessComboTest extends \PHPUnit_Framework_TestCase
+class SACJwtAccessComboTest extends TestCase
 {
     private $privateKey;
 

--- a/tests/Credentials/UserRefreshCredentialsTest.php
+++ b/tests/Credentials/UserRefreshCredentialsTest.php
@@ -21,6 +21,7 @@ use Google\Auth\ApplicationDefaultCredentials;
 use Google\Auth\Credentials\UserRefreshCredentials;
 use Google\Auth\OAuth2;
 use GuzzleHttp\Psr7;
+use PHPUnit\Framework\TestCase;
 
 // Creates a standard JSON auth object for testing.
 function createURCTestJson()
@@ -33,7 +34,7 @@ function createURCTestJson()
     ];
 }
 
-class URCGetCacheKeyTest extends \PHPUnit_Framework_TestCase
+class URCGetCacheKeyTest extends TestCase
 {
     public function testShouldBeTheSameAsOAuth2WithTheSameScope()
     {
@@ -50,7 +51,7 @@ class URCGetCacheKeyTest extends \PHPUnit_Framework_TestCase
     }
 }
 
-class URCConstructorTest extends \PHPUnit_Framework_TestCase
+class URCConstructorTest extends TestCase
 {
     /**
      * @expectedException InvalidArgumentException
@@ -111,7 +112,7 @@ class URCConstructorTest extends \PHPUnit_Framework_TestCase
     }
 }
 
-class URCFromEnvTest extends \PHPUnit_Framework_TestCase
+class URCFromEnvTest extends TestCase
 {
     protected function tearDown()
     {
@@ -141,7 +142,7 @@ class URCFromEnvTest extends \PHPUnit_Framework_TestCase
     }
 }
 
-class URCFromWellKnownFileTest extends \PHPUnit_Framework_TestCase
+class URCFromWellKnownFileTest extends TestCase
 {
     private $originalHome;
 
@@ -174,7 +175,7 @@ class URCFromWellKnownFileTest extends \PHPUnit_Framework_TestCase
     }
 }
 
-class URCFetchAuthTokenTest extends \PHPUnit_Framework_TestCase
+class URCFetchAuthTokenTest extends TestCase
 {
     /**
      * @expectedException GuzzleHttp\Exception\ClientException

--- a/tests/OAuth2Test.php
+++ b/tests/OAuth2Test.php
@@ -20,8 +20,9 @@ namespace Google\Auth\Tests;
 use Google\Auth\OAuth2;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
-class OAuth2AuthorizationUriTest extends \PHPUnit_Framework_TestCase
+class OAuth2AuthorizationUriTest extends TestCase
 {
     private $minimal = [
         'authorizationUri' => 'https://accounts.test.org/insecure/url',
@@ -170,7 +171,7 @@ class OAuth2AuthorizationUriTest extends \PHPUnit_Framework_TestCase
     }
 }
 
-class OAuth2GrantTypeTest extends \PHPUnit_Framework_TestCase
+class OAuth2GrantTypeTest extends TestCase
 {
     private $minimal = [
         'authorizationUri' => 'https://accounts.test.org/insecure/url',
@@ -232,7 +233,7 @@ class OAuth2GrantTypeTest extends \PHPUnit_Framework_TestCase
     }
 }
 
-class OAuth2GetCacheKeyTest extends \PHPUnit_Framework_TestCase
+class OAuth2GetCacheKeyTest extends TestCase
 {
     private $minimal = [
         'clientID' => 'aClientID',
@@ -259,7 +260,7 @@ class OAuth2GetCacheKeyTest extends \PHPUnit_Framework_TestCase
     }
 }
 
-class OAuth2TimingTest extends \PHPUnit_Framework_TestCase
+class OAuth2TimingTest extends TestCase
 {
     private $minimal = [
         'authorizationUri' => 'https://accounts.test.org/insecure/url',
@@ -319,7 +320,7 @@ class OAuth2TimingTest extends \PHPUnit_Framework_TestCase
     }
 }
 
-class OAuth2GeneralTest extends \PHPUnit_Framework_TestCase
+class OAuth2GeneralTest extends TestCase
 {
     private $minimal = [
         'authorizationUri' => 'https://accounts.test.org/insecure/url',
@@ -363,7 +364,7 @@ class OAuth2GeneralTest extends \PHPUnit_Framework_TestCase
     }
 }
 
-class OAuth2JwtTest extends \PHPUnit_Framework_TestCase
+class OAuth2JwtTest extends TestCase
 {
     private $signingMinimal = [
         'signingKey' => 'example_key',
@@ -481,7 +482,7 @@ class OAuth2JwtTest extends \PHPUnit_Framework_TestCase
     }
 }
 
-class OAuth2GenerateAccessTokenRequestTest extends \PHPUnit_Framework_TestCase
+class OAuth2GenerateAccessTokenRequestTest extends TestCase
 {
     private $tokenRequestMinimal = [
         'tokenCredentialUri' => 'https://tokens_r_us/test',
@@ -629,7 +630,7 @@ class OAuth2GenerateAccessTokenRequestTest extends \PHPUnit_Framework_TestCase
     }
 }
 
-class OAuth2FetchAuthTokenTest extends \PHPUnit_Framework_TestCase
+class OAuth2FetchAuthTokenTest extends TestCase
 {
     private $fetchAuthTokenMinimal = [
         'tokenCredentialUri' => 'https://tokens_r_us/test',
@@ -774,7 +775,7 @@ class OAuth2FetchAuthTokenTest extends \PHPUnit_Framework_TestCase
     }
 }
 
-class OAuth2VerifyIdTokenTest extends \PHPUnit_Framework_TestCase
+class OAuth2VerifyIdTokenTest extends TestCase
 {
     private $publicKey;
     private $privateKey;


### PR DESCRIPTION
A simple version of #174.

Now, I'm just updating to [`PHPUnit 4.8.36`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4836---2017-06-21), keep all PHP versions support, and use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).