### PR TITLE
Adds async method to HTTP handlers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,21 +11,24 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
 
 env:
-  - COMPOSER_CMD="composer install"
-  - COMPOSER_CMD="composer update --prefer-lowest"
+  -
+  - COMPOSER_ARGS="--prefer-lowest"
 matrix:
   include:
-    - php: "7.0"
-      env: RUN_CS_FIXER=true COMPOSER_CMD="composer install"
+    - php: "7.2"
+      env: RUN_CS_FIXER=true
 
 before_script:
-  - $COMPOSER_CMD
+  - composer update $COMPOSER_ARGS
 
 script:
   - if [ "${RUN_CS_FIXER}" = "true" ]; then
+      composer require --dev "friendsofphp/php-cs-fixer:^1.11";
       vendor/bin/php-cs-fixer fix --dry-run --diff --config-file=.php_cs .;
     else
+      composer require --dev "phpunit/phpunit:^4.8";
       vendor/bin/phpunit;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,7 @@ before_script:
 
 script:
   - if [ "${RUN_CS_FIXER}" = "true" ]; then
-      composer require --dev "friendsofphp/php-cs-fixer:^1.11";
       vendor/bin/php-cs-fixer fix --dry-run --diff --config-file=.php_cs .;
     else
-      composer require --dev "phpunit/phpunit:^4.8";
       vendor/bin/phpunit;
     fi

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,10 @@
     "psr/cache": "^1.0"
   },
   "require-dev": {
-    "guzzlehttp/promises": "0.1.1|^1.3"
+    "guzzlehttp/promises": "0.1.1|^1.3",
+    "friendsofphp/php-cs-fixer": "^1.11",
+    "phpunit/phpunit": "^4.8",
+    "sebastian/comparator": ">=1.2.3"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,7 @@
     "psr/cache": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "3.7.*",
-    "friendsofphp/php-cs-fixer": "^1.11"
+    "guzzlehttp/promises": "0.1.1|^1.3"
   },
   "autoload": {
     "psr-4": {

--- a/src/HttpHandler/Guzzle5HttpHandler.php
+++ b/src/HttpHandler/Guzzle5HttpHandler.php
@@ -72,8 +72,10 @@ class Guzzle5HttpHandler
         }
 
         $futureResponse = $this->client->send(
-            $this->createGuzzle5Request($request, $options),
-            ['future' => true] + $options
+            $this->createGuzzle5Request(
+                $request,
+                ['future' => true] + $options
+            )
         );
 
         $promise = new Promise(

--- a/src/HttpHandler/Guzzle5HttpHandler.php
+++ b/src/HttpHandler/Guzzle5HttpHandler.php
@@ -16,7 +16,11 @@
  */
 namespace Google\Auth\HttpHandler;
 
+use Exception;
 use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Message\ResponseInterface as Guzzle5ResponseInterface;
+use GuzzleHttp\Promise\Promise;
+use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Psr7\Response;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -46,7 +50,61 @@ class Guzzle5HttpHandler
      */
     public function __invoke(RequestInterface $request, array $options = [])
     {
-        $request = $this->client->createRequest(
+        $response = $this->client->send(
+            $this->createGuzzle5Request($request, $options)
+        );
+
+        return $this->createPsr7Response($response);
+    }
+
+    /**
+     * Accepts a PSR-7 request and an array of options and returns a PromiseInterface
+     *
+     * @param RequestInterface $request
+     * @param array $options
+     *
+     * @return Promise
+     */
+    public function async(RequestInterface $request, array $options = [])
+    {
+        if (!class_exists('GuzzleHttp\Promise\Promise')) {
+            throw new Exception('Install guzzlehttp/promises to use async with Guzzle 5');
+        }
+
+        $futureResponse = $this->client->send(
+            $this->createGuzzle5Request($request, $options),
+            ['future' => true] + $options
+        );
+
+        $promise = new Promise(
+            function () use ($futureResponse) {
+                try {
+                    $futureResponse->wait();
+                } catch (Exception $e) {
+                    throw $e;
+                    // The promise is already delivered when the exception is
+                    // thrown, so don't rethrow it.
+                }
+            },
+            [$futureResponse, 'cancel']
+        );
+
+        $futureResponse->then([$promise, 'resolve'], [$promise, 'reject']);
+
+        return $promise->then(
+            function (Guzzle5ResponseInterface $response) {
+                // Adapt the Guzzle 5 Response to a PSR-7 Response.
+                return $this->createPsr7Response($response);
+            },
+            function (Exception $e) {
+                return new RejectedPromise($e->getMessage());
+            }
+        );
+    }
+
+    private function createGuzzle5Request(RequestInterface $request, array $options)
+    {
+        return $this->client->createRequest(
             $request->getMethod(),
             $request->getUri(),
             array_merge([
@@ -54,9 +112,10 @@ class Guzzle5HttpHandler
                 'body' => $request->getBody(),
             ], $options)
         );
+    }
 
-        $response = $this->client->send($request);
-
+    private function createPsr7Response(Guzzle5ResponseInterface $response)
+    {
         return new Response(
             $response->getStatusCode(),
             $response->getHeaders() ?: [],

--- a/src/HttpHandler/Guzzle5HttpHandler.php
+++ b/src/HttpHandler/Guzzle5HttpHandler.php
@@ -83,7 +83,6 @@ class Guzzle5HttpHandler
                 try {
                     $futureResponse->wait();
                 } catch (Exception $e) {
-                    throw $e;
                     // The promise is already delivered when the exception is
                     // thrown, so don't rethrow it.
                 }
@@ -99,7 +98,7 @@ class Guzzle5HttpHandler
                 return $this->createPsr7Response($response);
             },
             function (Exception $e) {
-                return new RejectedPromise($e->getMessage());
+                return new RejectedPromise($e);
             }
         );
     }

--- a/src/HttpHandler/Guzzle6HttpHandler.php
+++ b/src/HttpHandler/Guzzle6HttpHandler.php
@@ -33,4 +33,17 @@ class Guzzle6HttpHandler
     {
         return $this->client->send($request, $options);
     }
+
+    /**
+     * Accepts a PSR-7 request and an array of options and returns a PromiseInterface
+     *
+     * @param RequestInterface $request
+     * @param array $options
+     *
+     * @return \GuzzleHttp\Promise\Promise
+     */
+    public function async(RequestInterface $request, array $options = [])
+    {
+        return $this->client->sendAsync($request, $options);
+    }
 }

--- a/tests/HttpHandler/Guzzle5HttpHandlerTest.php
+++ b/tests/HttpHandler/Guzzle5HttpHandlerTest.php
@@ -152,10 +152,10 @@ class Guzzle5HttpHandlerTest extends BaseTest
     }
 
     /**
-     * @expectedException GuzzleHttp\Promise\RejectionException
+     * @expectedException Exception
      * @expectedExceptionMessage This is a test rejection message
      */
-    public function testPromiseHandlesError()
+    public function testPromiseHandlesException()
     {
         $this->mockClient
             ->expects($this->any())

--- a/tests/HttpHandler/Guzzle5HttpHandlerTest.php
+++ b/tests/HttpHandler/Guzzle5HttpHandlerTest.php
@@ -51,7 +51,20 @@ class Guzzle5HttpHandlerTest extends BaseTest
                 ->getMock();
     }
 
-    public function testSuccessfullySendsRequest()
+    public function testSuccessfullySendsRealRequest()
+    {
+        $request = new \GuzzleHttp\Psr7\Request('get', 'http://httpbin.org/get');
+        $client = new \GuzzleHttp\Client();
+        $handler = new Guzzle5HttpHandler($client);
+        $response = $handler($request);
+        $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
+        $this->assertEquals(200, $response->getStatusCode());
+        $json = json_decode((string) $response->getBody(), true);
+        $this->assertArrayHasKey('url', $json);
+        $this->assertEquals($request->getUri(), $json['url']);
+    }
+
+    public function testSuccessfullySendsMockRequest()
     {
         $response = new Response(
             200,

--- a/tests/HttpHandler/Guzzle5HttpHandlerTest.php
+++ b/tests/HttpHandler/Guzzle5HttpHandlerTest.php
@@ -23,6 +23,7 @@ use Google\Auth\HttpHandler\Guzzle5HttpHandler;
 use GuzzleHttp\Message\FutureResponse;
 use GuzzleHttp\Message\Response;
 use GuzzleHttp\Ring\Future\CompletedFutureValue;
+use GuzzleHttp\Stream\Stream;
 
 class Guzzle5HttpHandlerTest extends BaseTest
 {
@@ -52,10 +53,15 @@ class Guzzle5HttpHandlerTest extends BaseTest
 
     public function testSuccessfullySendsRequest()
     {
+        $response = new Response(
+            200,
+            [],
+            Stream::factory('Body Text')
+        );
         $this->mockClient
             ->expects($this->any())
             ->method('send')
-            ->will($this->returnValue(new Response(200)));
+            ->will($this->returnValue($response));
         $this->mockClient
             ->expects($this->any())
             ->method('createRequest')
@@ -64,6 +70,8 @@ class Guzzle5HttpHandlerTest extends BaseTest
         $handler = new Guzzle5HttpHandler($this->mockClient);
         $response = $handler($this->mockPsr7Request);
         $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('Body Text', (string) $response->getBody());
     }
 
     public function testAsyncWithoutGuzzlePromiseThrowsException()
@@ -107,11 +115,16 @@ class Guzzle5HttpHandlerTest extends BaseTest
 
     public function testSuccessfullySendsRequestAsync()
     {
+        $response = new Response(
+            200,
+            [],
+            Stream::factory('Body Text')
+        );
         $this->mockClient
             ->expects($this->any())
             ->method('send')
             ->will($this->returnValue(new FutureResponse(
-                new CompletedFutureValue(new Response(200))
+                new CompletedFutureValue($response)
             )));
         $this->mockClient
             ->expects($this->any())
@@ -121,6 +134,8 @@ class Guzzle5HttpHandlerTest extends BaseTest
         $handler = new Guzzle5HttpHandler($this->mockClient);
         $promise = $handler->async($this->mockPsr7Request);
         $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $promise->wait());
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('Body Text', (string) $response->getBody());
     }
 
     /**

--- a/tests/HttpHandler/Guzzle5HttpHandlerTest.php
+++ b/tests/HttpHandler/Guzzle5HttpHandlerTest.php
@@ -17,8 +17,12 @@
 
 namespace Google\Auth\Tests;
 
+use Composer\Autoload\ClassLoader;
+use Exception;
 use Google\Auth\HttpHandler\Guzzle5HttpHandler;
+use GuzzleHttp\Message\FutureResponse;
 use GuzzleHttp\Message\Response;
+use GuzzleHttp\Ring\Future\CompletedFutureValue;
 
 class Guzzle5HttpHandlerTest extends BaseTest
 {
@@ -39,6 +43,11 @@ class Guzzle5HttpHandlerTest extends BaseTest
                 ->getMockBuilder('GuzzleHttp\Client')
                 ->disableOriginalConstructor()
                 ->getMock();
+        $this->mockFuture =
+            $this
+                ->getMockBuilder('GuzzleHttp\Ring\Future\FutureInterface')
+                ->disableOriginalConstructor()
+                ->getMock();
     }
 
     public function testSuccessfullySendsRequest()
@@ -55,5 +64,87 @@ class Guzzle5HttpHandlerTest extends BaseTest
         $handler = new Guzzle5HttpHandler($this->mockClient);
         $response = $handler($this->mockPsr7Request);
         $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
+    }
+
+    public function testAsyncWithoutGuzzlePromiseThrowsException()
+    {
+        // Pretend the promise library doesn't exist
+        foreach (spl_autoload_functions() as $function) {
+            if ($function[0] instanceof ClassLoader) {
+                $newAutoloader = clone $function[0];
+                $newAutoloader->setPsr4('GuzzleHttp\\Promise\\', '/tmp');
+                spl_autoload_register($newAutoloadFunc = [$newAutoloader, 'loadClass']);
+                spl_autoload_unregister($previousAutoloadFunc = $function);
+            }
+        }
+        $this->mockClient
+            ->expects($this->any())
+            ->method('send')
+            ->will($this->returnValue(new FutureResponse($this->mockFuture)));
+        $this->mockClient
+            ->expects($this->any())
+            ->method('createRequest')
+            ->will($this->returnValue($this->mockRequest));
+
+        $handler = new Guzzle5HttpHandler($this->mockClient);
+        $errorThrown = false;
+        try {
+            $handler->async($this->mockPsr7Request);
+        } catch (Exception $e) {
+            $this->assertEquals(
+                'Install guzzlehttp/promises to use async with Guzzle 5',
+                $e->getMessage()
+            );
+            $errorThrown = true;
+        }
+
+        // Restore autoloader before assertion (in case it fails)
+        spl_autoload_register($previousAutoloadFunc);
+        spl_autoload_unregister($newAutoloadFunc);
+
+        $this->assertTrue($errorThrown);
+    }
+
+    public function testSuccessfullySendsRequestAsync()
+    {
+        $this->mockClient
+            ->expects($this->any())
+            ->method('send')
+            ->will($this->returnValue(new FutureResponse(
+                new CompletedFutureValue(new Response(200))
+            )));
+        $this->mockClient
+            ->expects($this->any())
+            ->method('createRequest')
+            ->will($this->returnValue($this->mockRequest));
+
+        $handler = new Guzzle5HttpHandler($this->mockClient);
+        $promise = $handler->async($this->mockPsr7Request);
+        $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $promise->wait());
+    }
+
+    /**
+     * @expectedException GuzzleHttp\Promise\RejectionException
+     * @expectedExceptionMessage This is a test rejection message
+     */
+    public function testPromiseHandlesError()
+    {
+        $this->mockClient
+            ->expects($this->any())
+            ->method('send')
+            ->will($this->returnValue(new FutureResponse(
+                (new CompletedFutureValue(new Response(200)))
+                    ->then(function () {
+                        throw new Exception('This is a test rejection message');
+                    })
+            )));
+        $this->mockClient
+            ->expects($this->any())
+            ->method('createRequest')
+            ->will($this->returnValue($this->mockRequest));
+
+        $handler = new Guzzle5HttpHandler($this->mockClient);
+        $promise = $handler->async($this->mockPsr7Request);
+        $promise->wait();
     }
 }

--- a/tests/HttpHandler/Guzzle6HttpHandlerTest.php
+++ b/tests/HttpHandler/Guzzle6HttpHandlerTest.php
@@ -18,6 +18,7 @@
 namespace Google\Auth\Tests;
 
 use Google\Auth\HttpHandler\Guzzle6HttpHandler;
+use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Psr7\Response;
 
 class Guzzle6HttpHandlerTest extends BaseTest
@@ -46,5 +47,19 @@ class Guzzle6HttpHandlerTest extends BaseTest
         $handler = new Guzzle6HttpHandler($this->mockClient);
         $response = $handler($this->mockRequest);
         $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
+    }
+
+    public function testSuccessfullySendsRequestAsync()
+    {
+        $this->mockClient
+            ->expects($this->any())
+            ->method('sendAsync')
+            ->will($this->returnValue(new Promise(function () use (&$promise) {
+                return $promise->resolve(new Response(200));
+            })));
+
+        $handler = new Guzzle6HttpHandler($this->mockClient);
+        $promise = $handler->async($this->mockRequest);
+        $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $promise->wait());
     }
 }

--- a/tests/HttpHandler/Guzzle6HttpHandlerTest.php
+++ b/tests/HttpHandler/Guzzle6HttpHandlerTest.php
@@ -55,11 +55,14 @@ class Guzzle6HttpHandlerTest extends BaseTest
             ->expects($this->any())
             ->method('sendAsync')
             ->will($this->returnValue(new Promise(function () use (&$promise) {
-                return $promise->resolve(new Response(200));
+                return $promise->resolve(new Response(200, [], 'Body Text'));
             })));
 
         $handler = new Guzzle6HttpHandler($this->mockClient);
         $promise = $handler->async($this->mockRequest);
-        $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $promise->wait());
+        $response = $promise->wait();
+        $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('Body Text', (string) $response->getBody());
     }
 }


### PR DESCRIPTION
Allows the HTTP Handlers to be used asynchronously w/o breaking backwards compatibility with the auth library.

@dwsupplee @michaelbausor 