### PR TITLE
Refactoring tests

### DIFF
--- a/tests/Credentials/IAMCredentialsTest.php
+++ b/tests/Credentials/IAMCredentialsTest.php
@@ -66,17 +66,15 @@ class IAMUpdateMetadataCallbackTest extends TestCase
         );
 
         $update_metadata = $iam->getUpdateMetadataFunc();
-        $this->assertTrue(is_callable($update_metadata));
+        $this->assertInternalType('callable', $update_metadata);
 
         $actual_metadata = call_user_func($update_metadata,
             $metadata = array('foo' => 'bar'));
-        $this->assertTrue(
-            isset($actual_metadata[IAMCredentials::SELECTOR_KEY]));
+        $this->assertArrayHasKey(IAMCredentials::SELECTOR_KEY, $actual_metadata);
         $this->assertEquals(
             $actual_metadata[IAMCredentials::SELECTOR_KEY],
             $selector);
-        $this->assertTrue(
-            isset($actual_metadata[IAMCredentials::TOKEN_KEY]));
+        $this->assertArrayHasKey(IAMCredentials::TOKEN_KEY, $actual_metadata);
         $this->assertEquals(
             $actual_metadata[IAMCredentials::TOKEN_KEY],
             $token);

--- a/tests/Credentials/ServiceAccountCredentialsTest.php
+++ b/tests/Credentials/ServiceAccountCredentialsTest.php
@@ -294,14 +294,16 @@ class SACFetchAuthTokenTest extends TestCase
             $testJson
         );
         $update_metadata = $sa->getUpdateMetadataFunc();
-        $this->assertTrue(is_callable($update_metadata));
+        $this->assertInternalType('callable', $update_metadata);
 
         $actual_metadata = call_user_func($update_metadata,
             $metadata = array('foo' => 'bar'),
             $authUri = null,
             $httpHandler);
-        $this->assertTrue(
-            isset($actual_metadata[CredentialsLoader::AUTH_METADATA_KEY]));
+        $this->assertArrayHasKey(
+            CredentialsLoader::AUTH_METADATA_KEY,
+            $actual_metadata
+        );
         $this->assertEquals(
             $actual_metadata[CredentialsLoader::AUTH_METADATA_KEY],
             array('Bearer ' . $access_token));
@@ -383,13 +385,15 @@ class SACJwtAccessTest extends TestCase
         $this->assertNotNull($sa);
 
         $update_metadata = $sa->getUpdateMetadataFunc();
-        $this->assertTrue(is_callable($update_metadata));
+        $this->assertInternalType('callable', $update_metadata);
 
         $actual_metadata = call_user_func($update_metadata,
             $metadata = array('foo' => 'bar'),
             $authUri = null);
-        $this->assertTrue(
-            !isset($actual_metadata[CredentialsLoader::AUTH_METADATA_KEY]));
+        $this->assertArrayNotHasKey(
+            CredentialsLoader::AUTH_METADATA_KEY,
+            $actual_metadata
+        );
     }
 
     public function testUpdateMetadataFunc()
@@ -401,36 +405,40 @@ class SACJwtAccessTest extends TestCase
         $this->assertNotNull($sa);
 
         $update_metadata = $sa->getUpdateMetadataFunc();
-        $this->assertTrue(is_callable($update_metadata));
+        $this->assertInternalType('callable', $update_metadata);
 
         $actual_metadata = call_user_func($update_metadata,
             $metadata = array('foo' => 'bar'),
             $authUri = 'https://example.com/service');
-        $this->assertTrue(
-            isset($actual_metadata[CredentialsLoader::AUTH_METADATA_KEY]));
+        $this->assertArrayHasKey(
+            CredentialsLoader::AUTH_METADATA_KEY,
+            $actual_metadata
+        );
 
         $authorization = $actual_metadata[CredentialsLoader::AUTH_METADATA_KEY];
-        $this->assertTrue(is_array($authorization));
+        $this->assertInternalType('array', $authorization);
 
         $bearer_token = current($authorization);
-        $this->assertTrue(is_string($bearer_token));
-        $this->assertTrue(strpos($bearer_token, 'Bearer ') == 0);
-        $this->assertTrue(strlen($bearer_token) > 30);
+        $this->assertInternalType('string', $bearer_token);
+        $this->assertEquals(0, strpos($bearer_token, 'Bearer '));
+        $this->assertGreaterThan(30, strlen($bearer_token));
 
         $actual_metadata2 = call_user_func($update_metadata,
             $metadata = array('foo' => 'bar'),
             $authUri = 'https://example.com/anotherService');
-        $this->assertTrue(
-            isset($actual_metadata2[CredentialsLoader::AUTH_METADATA_KEY]));
+        $this->assertArrayHasKey(
+            CredentialsLoader::AUTH_METADATA_KEY,
+            $actual_metadata2
+        );
 
         $authorization2 = $actual_metadata2[CredentialsLoader::AUTH_METADATA_KEY];
-        $this->assertTrue(is_array($authorization2));
+        $this->assertInternalType('array', $authorization2);
 
         $bearer_token2 = current($authorization2);
-        $this->assertTrue(is_string($bearer_token2));
-        $this->assertTrue(strpos($bearer_token2, 'Bearer ') == 0);
-        $this->assertTrue(strlen($bearer_token2) > 30);
-        $this->assertTrue($bearer_token != $bearer_token2);
+        $this->assertInternalType('string', $bearer_token2);
+        $this->assertEquals(0, strpos($bearer_token2, 'Bearer '));
+        $this->assertGreaterThan(30, strlen($bearer_token2));
+        $this->assertNotEquals($bearer_token2, $bearer_token);
     }
 }
 
@@ -465,21 +473,23 @@ class SACJwtAccessComboTest extends TestCase
         $this->assertNotNull($sa);
 
         $update_metadata = $sa->getUpdateMetadataFunc();
-        $this->assertTrue(is_callable($update_metadata));
+        $this->assertInternalType('callable', $update_metadata);
 
         $actual_metadata = call_user_func($update_metadata,
             $metadata = array('foo' => 'bar'),
             $authUri = 'https://example.com/service');
-        $this->assertTrue(
-            isset($actual_metadata[CredentialsLoader::AUTH_METADATA_KEY]));
+        $this->assertArrayHasKey(
+            CredentialsLoader::AUTH_METADATA_KEY,
+            $actual_metadata
+        );
 
         $authorization = $actual_metadata[CredentialsLoader::AUTH_METADATA_KEY];
-        $this->assertTrue(is_array($authorization));
+        $this->assertInternalType('array', $authorization);
 
         $bearer_token = current($authorization);
-        $this->assertTrue(is_string($bearer_token));
-        $this->assertTrue(strpos($bearer_token, 'Bearer ') == 0);
-        $this->assertTrue(strlen($bearer_token) > 30);
+        $this->assertInternalType('string', $bearer_token);
+        $this->assertEquals(0, strpos($bearer_token, 'Bearer '));
+        $this->assertGreaterThan(30, strlen($bearer_token));
     }
 
     public function testNoScopeAndNoAuthUri()
@@ -495,15 +505,17 @@ class SACJwtAccessComboTest extends TestCase
         $this->assertNotNull($sa);
 
         $update_metadata = $sa->getUpdateMetadataFunc();
-        $this->assertTrue(is_callable($update_metadata));
+        $this->assertInternalType('callable', $update_metadata);
 
         $actual_metadata = call_user_func($update_metadata,
             $metadata = array('foo' => 'bar'),
             $authUri = null);
         // no access_token is added to the metadata hash
         // but also, no error should be thrown
-        $this->assertTrue(is_array($actual_metadata));
-        $this->assertTrue(
-            !isset($actual_metadata[CredentialsLoader::AUTH_METADATA_KEY]));
+        $this->assertInternalType('array', $actual_metadata);
+        $this->assertArrayNotHasKey(
+            CredentialsLoader::AUTH_METADATA_KEY,
+            $actual_metadata
+        );
     }
 }

--- a/tests/OAuth2Test.php
+++ b/tests/OAuth2Test.php
@@ -610,7 +610,7 @@ class OAuth2GenerateAccessTokenRequestTest extends TestCase
         $this->assertEquals('POST', $req->getMethod());
         $fields = Psr7\parse_query((string)$req->getBody());
         $this->assertEquals(OAuth2::JWT_URN, $fields['grant_type']);
-        $this->assertTrue(array_key_exists('assertion', $fields));
+        $this->assertArrayHasKey('assertion', $fields);
     }
 
     public function testGeneratesExtendedRequests()


### PR DESCRIPTION
I've refactored some tests, using:
- `assertFalse` instead of `assertTrue` with `!` before the condition;
- `assertInternalType`, avoiding using `is_*` functions;
- `assertGreaterThan` for mathematical comparisons;
- `assertArrayHasKey` and `assertArrayNotHasKey` instead of `array_key_exists` and `isset` functions;
- `assertEquals` and `assertNotEquals` instead of comparisons.