### PR TITLE
Fix bug when merging headers on Guzzle5 http handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.2.1 (23/12/2017)
+
+### Changes
+
+* [#180] (https://github.com/google/google-auth-library-php/issues/180): Fix bug when merging headers on Guzzle5 http handler (@erictinocopro[])
+
 ## 1.0.0 (12/06/2017)
 
 ### Changes
@@ -16,3 +22,4 @@
 
 [@bshaffer]: https://github.com/bshaffer
 [@stanley-cheung]: https://github.com/stanley-cheung
+[@erictinocopro]: https://github.com/erictinocopro

--- a/src/HttpHandler/Guzzle5HttpHandler.php
+++ b/src/HttpHandler/Guzzle5HttpHandler.php
@@ -108,7 +108,7 @@ class Guzzle5HttpHandler
         return $this->client->createRequest(
             $request->getMethod(),
             $request->getUri(),
-            array_merge([
+            array_merge_recursive([
                 'headers' => $request->getHeaders(),
                 'body' => $request->getBody(),
             ], $options)


### PR DESCRIPTION
This will avoid removing already set headers with headers from options (like encryption)