### PR TITLE
Pass correct parameter to AuthTokenMiddleware

### DIFF
--- a/src/ApplicationDefaultCredentials.php
+++ b/src/ApplicationDefaultCredentials.php
@@ -114,7 +114,7 @@ class ApplicationDefaultCredentials
     ) {
         $creds = self::getCredentials($scope, $httpHandler, $cacheConfig, $cache);
 
-        return new AuthTokenMiddleware($creds, $cacheConfig);
+        return new AuthTokenMiddleware($creds, $httpHandler);
     }
 
     /**


### PR DESCRIPTION
`AuthTokenMiddleware` expects a `$httpCallable`, but is being passed `$cacheConfig`.