### PR TITLE
fix - guzzlehttp/psr7 dependency version definition

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "php": ">=5.4",
     "firebase/php-jwt": "~2.0|~3.0|~4.0|~5.0",
     "guzzlehttp/guzzle": "~5.3.1|~6.0",
-    "guzzlehttp/psr7": "~1.2",
+    "guzzlehttp/psr7": "^1.2",
     "psr/http-message": "^1.0",
     "psr/cache": "^1.0"
   },


### PR DESCRIPTION
Google api client relies on guzzlehttp/psr7:^1.2